### PR TITLE
Continue tune up of QR code parsing tool for reproflow-data-sync purposes

### DIFF
--- a/Parsing/generate_qrinfo.sh
+++ b/Parsing/generate_qrinfo.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Script to generate QR info JSONL data and logs for ReproNim session with parse_wQR.py tool"
+  echo "Usage: $0 <session_dir>"
+  exit 1
+fi
+
+# Set SESSION_DIR to the first command-line argument
+SESSION_DIR=$1
+IN_DIR=$SESSION_DIR/reprostim-videos
+OUT_DIR=$SESSION_DIR/timing-reprostim-videos
+LOG_LEVEL=DEBUG
+
+echo "Generating QR info reprostim videos in session: $SESSION_DIR"
+echo "Session reprostim video directory: $IN_DIR"
+echo "QR info and logs will be saved to: $OUT_DIR"
+
+# Create the out directory if it does not exist
+if [ ! -d "$OUT_DIR" ]; then
+  mkdir -p "$OUT_DIR"
+  echo "Created directory: $OUT_DIR"
+fi
+
+# Count the number of .mkv files
+total_files=$(ls "$IN_DIR"/*.mkv 2>/dev/null | wc -l | xargs)
+echo "Total *.mkv files count: $total_files"
+counter=1
+
+# Iterate over .mkv files in IN_DIR
+for file in "$IN_DIR"/*.mkv;
+do
+  base_name=$(basename "$file" .mkv)
+  echo "Processing $counter/$total_files : $file..."
+  # this is normal video parsing:
+  #./parse_wQR.py --log-level $LOG_LEVEL $file >$OUT_DIR/$base_name.qrinfo.jsonl 2>$OUT_DIR/$base_name.qrinfo.log
+
+  # but we have invalid videos, so cleanup it first
+  tmp_mkv_file=$OUT_DIR/$base_name.mkv
+  echo "Generating tmp *.mkv file $tmp_mkv_file..."
+  ffmpeg -i $file -an -c copy $tmp_mkv_file
+  ./parse_wQR.py --log-level $LOG_LEVEL $tmp_mkv_file >$OUT_DIR/$base_name.qrinfo.jsonl 2>$OUT_DIR/$base_name.qrinfo.log
+  if [ -e "tmp_mkv_file" ]; then
+    echo "Deleting tmp *.mkv file: tmp_mkv_file"
+    rm "$out_file"
+  fi
+
+  counter=$((counter + 1))
+done
+
+# Generate QR info
+#echo "Generating QR info data..."
+#./parse_wQR.py --log-level $LOG_LEVEL $SESSION_DIR >$OUT_DIR/dump_qrinfo.jsonl 2>$OUT_DIR/dump_qrinfo.log
+#echo "dump_qrinfo.py exit code: $?"

--- a/Parsing/generate_qrinfo.sh
+++ b/Parsing/generate_qrinfo.sh
@@ -40,9 +40,9 @@ do
   echo "Generating tmp *.mkv file $tmp_mkv_file..."
   ffmpeg -i $file -an -c copy $tmp_mkv_file
   ./parse_wQR.py --log-level $LOG_LEVEL $tmp_mkv_file >$OUT_DIR/$base_name.qrinfo.jsonl 2>$OUT_DIR/$base_name.qrinfo.log
-  if [ -e "tmp_mkv_file" ]; then
-    echo "Deleting tmp *.mkv file: tmp_mkv_file"
-    rm "$out_file"
+  if [ -e "$tmp_mkv_file" ]; then
+    echo "Deleting tmp *.mkv file: $tmp_mkv_file"
+    rm "$tmp_mkv_file"
   fi
 
   counter=$((counter + 1))


### PR DESCRIPTION
To work on #13 issue and #14 issue some polishing in `parse_wQR.py` tool still necessary:

- [x] `generate_qrinfo.sh` script working with https://github.com/ReproNim/reproflow-data-sync data structure to generate QR codes JSONL info under `timing-reprostim-videos` folder.
- [x] Consider adding `REPROSTIM-METADATA-JSON` data in jsonl output as separate line or integrated as fields.
- [x] Extend `parse_wQR.py` script with INFO mode to dump videos information like duration, bitrate, size in JSON format to better understand recorded videos status when tunning `ffmpeg` options.

Possible ideas/issues for next tasks in this area:
- Use information from .mkv.log file marked with `REPROSTIM-METADATA-JSON` magic words to extract video metadata like video start/end timestamp rather than parsing .mkv file name (WiP).
