### PR TITLE
Investigate and fix frames dropping issues in videocapture found in ses-20240830

### DIFF
--- a/Capture/research/ffmpeg_enc/ffmpeg_enc.sh
+++ b/Capture/research/ffmpeg_enc/ffmpeg_enc.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+#set VDEV=/dev/video1
+#set MKV=./1.mkv
+
+#echo "Test 1"
+
+#rm $MKV
+#ffmpeg -f v4l2 -input_format yuyv422 -framerate 60 -video_size 1920x1080 -thread_queue_size 40960 -i $VDEV -c:v libx264 -flush_packets 1 -an $MKV
+
+#ffmpeg -f alsa -ac 2 -thread_queue_size 4096 -i hw:1,1
+ # -f v4l2 -input_format yuyv422 -framerate 60 -video_size 1920x1080 -thread_queue_size 4096
+ # -i /dev/video0 -c:v libx264 -flush_packets 1
+ # -acodec aac ./1.mkv 2>&1
+
+# Simple 15 sec video capture with no audio
+#echo "Test 001"
+#rm output001.mp4
+#/usr/bin/time -v ffmpeg -f v4l2 -framerate 60 -video_size 1920x1080 -t 15 -i /dev/video0 -an output001.mp4
+
+# Simple 15 sec video capture with no audio and x264 codec
+#echo "Test 002"
+#rm output002.mp4
+#/usr/bin/time -v ffmpeg -f v4l2 -framerate 60 -video_size 1920x1080 -t 15 -i /dev/video0 -c:v libx264 -an output002.mp4
+
+# Simple video capture with audio and video and start time set to 0 for both audio and video
+#echo "Test 003"
+#rm output003.mp4
+#ffmpeg -f alsa -ac 2 -thread_queue_size 4096 -i hw:1,1 -f v4l2 -framerate 60 -video_size 1920x1080 -i /dev/video0 -c:v libx264 -acodec aac -vf setpts=PTS-STARTPTS -af asetpts=PTS-STARTPTS output003.mp4
+
+# video capture with x264 optimizations: fast 2M bit rate
+#echo "Test 004"
+#rm output004.mp4
+#/usr/bin/time -v ffmpeg -f alsa -t 15 -ac 2 -thread_queue_size 4096 -i hw:1,1 -f v4l2 -t 15 -framerate 60 -video_size 1920x1080 -i /dev/video0 -c:v libx264 -b:v 2M -preset fast -acodec aac -vf setpts=PTS-STARTPTS -af asetpts=PTS-STARTPTS output004.mp4
+
+# video capture with x264 optimizations: ultrafast
+#echo "Test 005"
+#rm output005.mp4
+#/usr/bin/time -v ffmpeg -f alsa -t 15 -ac 2 -thread_queue_size 4096 -i hw:1,1 -f v4l2 -t 15 -framerate 60 -video_size 1920x1080 -i /dev/video0 -c:v libx264 -b:v 2M -preset ultrafast -acodec aac -vf setpts=PTS-STARTPTS -af asetpts=PTS-STARTPTS output005.mp4
+
+# video capture with x264 optimizations: ultrafast, crf=18 r-60?
+#echo "Test 006"
+#rm output006.mp4
+#/usr/bin/time -v ffmpeg -f alsa -t 15 -ac 2 -thread_queue_size 4096 -i hw:1,1 -f v4l2 -t 15 -framerate 60 -video_size 1920x1080 -i /dev/video0 -c:v libx264 -r 60 -b:v 2M -preset ultrafast -crf 18 -acodec aac -vf setpts=PTS-STARTPTS -af asetpts=PTS-STARTPTS output006.mp4
+
+# video capture with x264 optimizations: ultrafast, crf=18 zerolatency
+# 470M/hour
+#echo "Test 007"
+#rm output007.mp4
+#/usr/bin/time -v ffmpeg -f alsa -t 600 -ac 2 -thread_queue_size 4096 -i hw:1,1 -f v4l2 -t 600 -framerate 60 -video_size 1920x1080 -i /dev/video0 -c:v libx264 -flush_packets 1 -preset ultrafast -crf 18 -r 60 -tune zerolatency -b:v 2M -maxrate 2M -bufsize 4M  -acodec aac -vf setpts=PTS-STARTPTS -af asetpts=PTS-STARTPTS output007.mp4
+
+# video capture with x264 optimizations: ultrafast, crf=18 zerolatency
+echo "Test 008"
+rm output008.mp4
+/usr/bin/time -v ffmpeg -f alsa -t 15 -ac 2 -thread_queue_size 4096 -i hw:1,1 -f v4l2 -t 15 -framerate 60 -video_size 1920x1080 -i /dev/video0 -c:v libx264 -flush_packets 1 -preset ultrafast -crf 18 -r 60 -tune zerolatency -b:v 2M -maxrate 2M -bufsize 4M  -acodec aac -vf setpts=PTS-STARTPTS -af asetpts=PTS-STARTPTS output008.mp4
+

--- a/Capture/research/ffmpeg_enc/results.txt
+++ b/Capture/research/ffmpeg_enc/results.txt
@@ -1,0 +1,149 @@
+#001
+Command being timed: "ffmpeg -f v4l2 -framerate 60 -video_size 1920x1080 -t 15 -i /dev/video0 -an output001.mp4"
+	User time (seconds): 43.02
+	System time (seconds): 1.53
+	Percent of CPU this job got: 287%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:15.47
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 903284
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 0
+	Minor (reclaiming a frame) page faults: 30993
+	Voluntary context switches: 26455
+	Involuntary context switches: 2409
+	Swaps: 0
+	File system inputs: 0
+	File system outputs: 768
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0
+
+#002
+	Command being timed: "ffmpeg -f v4l2 -framerate 60 -video_size 1920x1080 -t 15 -i /dev/video0 -c:v libx264 -an output002.mp4"
+	User time (seconds): 43.84
+	System time (seconds): 1.68
+	Percent of CPU this job got: 293%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:15.49
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 897268
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 0
+	Minor (reclaiming a frame) page faults: 30973
+	Voluntary context switches: 25319
+	Involuntary context switches: 2829
+	Swaps: 0
+	File system inputs: 0
+	File system outputs: 552
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0
+
+#004
+	Command being timed: "ffmpeg -f alsa -t 15 -ac 2 -thread_queue_size 4096 -i hw:1,1 -f v4l2 -t 15 -framerate 60 -video_size 1920x1080 -i /dev/video0 -c:v libx264 -b:v 2M -preset fast -acodec aac -vf setpts=PTS-STARTPTS -af asetpts=PTS-STARTPTS output004.mp4"
+	User time (seconds): 51.62
+	System time (seconds): 1.73
+	Percent of CPU this job got: 340%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:15.65
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 810976
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 0
+	Minor (reclaiming a frame) page faults: 27510
+	Voluntary context switches: 29507
+	Involuntary context switches: 4373
+	Swaps: 0
+	File system inputs: 0
+	File system outputs: 7416
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0
+
+#005
+Command being timed: "ffmpeg -f alsa -t 15 -ac 2 -thread_queue_size 4096 -i hw:1,1 -f v4l2 -t 15 -framerate 60 -video_size 1920x1080 -i /dev/video0 -c:v libx264 -b:v 2M -preset ultrafast -acodec aac -vf setpts=PTS-STARTPTS -af asetpts=PTS-STARTPTS output005.mp4"
+	User time (seconds): 21.69
+	System time (seconds): 1.79
+	Percent of CPU this job got: 153%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:15.34
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 392000
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 0
+	Minor (reclaiming a frame) page faults: 15641
+	Voluntary context switches: 19262
+	Involuntary context switches: 926
+	Swaps: 0
+	File system inputs: 0
+	File system outputs: 7320
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0
+
+#006
+Command being timed: "ffmpeg -f alsa -t 15 -ac 2 -thread_queue_size 4096 -i hw:1,1 -f v4l2 -t 15 -framerate 60 -video_size 1920x1080 -i /dev/video0 -c:v libx264 -b:v 2M -preset ultrafast -crf 18 -acodec aac -vf setpts=PTS-STARTPTS -af asetpts=PTS-STARTPTS output006.mp4"
+	User time (seconds): 21.57
+	System time (seconds): 1.20
+	Percent of CPU this job got: 148%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:15.33
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 391756
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 0
+	Minor (reclaiming a frame) page faults: 15629
+	Voluntary context switches: 19737
+	Involuntary context switches: 746
+	Swaps: 0
+	File system inputs: 0
+	File system outputs: 3584
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0
+
+#007
+Command being timed: "ffmpeg -f alsa -t 15 -ac 2 -thread_queue_size 4096 -i hw:1,1 -f v4l2 -t 15 -framerate 60 -video_size 1920x1080 -i /dev/video0 -c:v libx264 -preset ultrafast -crf 18 -r 60 -tune zerolatency -b:v 2M -maxrate 2M -bufsize 4M -acodec aac -vf setpts=PTS-STARTPTS -af asetpts=PTS-STARTPTS output007.mp4"
+	User time (seconds): 25.16
+	System time (seconds): 1.19
+	Percent of CPU this job got: 172%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:15.30
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 235288
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 0
+	Minor (reclaiming a frame) page faults: 8124
+	Voluntary context switches: 36576
+	Involuntary context switches: 1681
+	Swaps: 0
+	File system inputs: 0
+	File system outputs: 2952
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0

--- a/Capture/videocapture/config.yaml
+++ b/Capture/videocapture/config.yaml
@@ -90,10 +90,9 @@ ffm_opts:
   #
   #v_dev: "/dev/video4"
   v_dev: "auto"
-  v_enc: "-c:v libx264 -flush_packets 1"
-  #v_enc: "-c:v libx264 -preset veryslow -crf 0"
+  v_enc: "-c:v libx264 -flush_packets 1 -preset ultrafast -crf 18 -tune zerolatency -b:v 2M -maxrate 2M -bufsize 4M -vf setpts=PTS-STARTPTS"
   pix_fmt: ""
   #pix_fmt: "-pix_fmt yuv420p"
-  n_threads: ""
-  a_enc: "-acodec aac"
+  n_threads: "-threads 4"
+  a_enc: "-acodec aac -af asetpts=PTS-STARTPTS"
   out_fmt: "mkv"


### PR DESCRIPTION
This PR is brother of issue #68 we have with frames dropping. Got this issue in ReproNim ses-20240830 time calibration session. Proposal is listed below:

- [ ] Specify non-default H.264 configuration with less resources consuming like CPU, play with CRF, and other CPU/GPU build-in features.
- [ ] Fix video duration issue. Mkv container has both video and audio streams and looks like they are not synced well.
- [ ] ffmpeg capture process auto-recovery and relibality. According to logs, looks like in the session ffmpeg was killed few minutes before video signal was disconnected. It might be result of Linux OOM killer or similar, and `sudo dmesg | grep -i "killed process"` lists these events. Capturing process should detect this situation and restart ffmpeg to continue recording, and may be with additional logs/notes indicating that video is divided and not continious.

Reconfigure videocapture/ffmpeg options:

- TDB



