### PR TITLE
Fixes basic tests execution under conda-forge.

### DIFF
--- a/src/reprostim/audio/audiocodes.py
+++ b/src/reprostim/audio/audiocodes.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+# optionally: import sounddevice as sd
+import importlib
 import logging
 import os
 import tempfile
@@ -10,10 +12,16 @@ from datetime import datetime
 from enum import Enum
 
 import numpy as np
-import sounddevice as sd
 from reedsolo import RSCodec
 from scipy.io import wavfile
 from scipy.io.wavfile import read, write
+
+sd = (
+    importlib.import_module("sounddevice")
+    if importlib.util.find_spec("sounddevice")
+    else None
+)
+
 
 # setup logging
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
As part of conda-forge integration [#29029](https://github.com/conda-forge/staged-recipes/pull/29029) :
- Make sounddevice dependency optional in audiocodes.