### PR TITLE
Fixes basic tests execution under conda-forge #2

### DIFF
--- a/src/reprostim/audio/audiocodes.py
+++ b/src/reprostim/audio/audiocodes.py
@@ -56,7 +56,6 @@ try:
         logger.debug("Set psychopy audio library: ptb")
         prefs.hardware["audioLib"] = ["ptb"]
 
-    # logger.info("Using psychopy audio library: %s", prefs.hardware['audioLib'])
     from psychopy import core, sound  # noqa: E402
     from psychtoolbox import audio  # noqa: E402
 except ImportError:


### PR DESCRIPTION
As part of conda-forge integration [#29029](https://github.com/conda-forge/staged-recipes/pull/29029) :
- Make psychopy optional in audiocodes.