### PR TITLE
Provide custom filter function for Psychopy logs

### DIFF
--- a/src/reprostim/qr/timesync_stimuli.py
+++ b/src/reprostim/qr/timesync_stimuli.py
@@ -11,7 +11,7 @@ API to parse `(*.mkv)` video files recorded by `reprostim-videocapture`
 utility and extract embedded video media info, QR-codes and audiocodes into
 JSONL format.
 """
-
+import types
 from dataclasses import dataclass
 from time import sleep, time
 
@@ -338,6 +338,17 @@ def do_main(
     # late psychopy init
     # setup psychopy logs
     from psychopy import logging as pl
+
+    # psychopy logging doesn't support filtering by message content,
+    # so this is a patch to filter out flooding messages like "No keypress"
+    _pl_log_method = pl.root.log
+
+    def pl_filtered_log(self, message_, level, t=None, obj=None):
+        if "No keypress (maxWait exceeded)" in str(message_):
+            return
+        _pl_log_method(message_, level, t, obj)
+
+    pl.root.log = types.MethodType(pl_filtered_log, pl.root)
 
     # pl.console.setLevel(pl.NOTSET)
     pl.console.setLevel(pl.DEBUG)


### PR DESCRIPTION
Psychopy has own logger (`psychopy.logging._Logger`) w/o filtering functionality. In the PR we created custom `log` function and filtered out "No keypress (maxWait exceeded)" log message.

Closes #157.