### PR TITLE
Upgrade `PsychoPy` to version 2025.2.0 and fix docker container libs 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,9 +22,16 @@ jobs:
         run: |
           (
             echo "$PWD"
+
+            echo "Docker images BEFORE build:"
+            docker images
+
             export REPROSTIM_CAPTURE_ENABLED=1
             export REPROSTIM_DOCKER_TAGS="master unstable"
             ./build_reprostim_container.sh docker
+
+            echo "Docker images AFTER build:"
+            docker images
           )
         working-directory: tools/ci
 
@@ -36,6 +43,8 @@ jobs:
           (
             echo "$PWD"
             export REPROSTIM_CONTAINER_TYPE=docker
+            # specify latest unstable image to test
+            export REPROSTIM_CONTAINER_IMAGE=repronim/reprostim:unstable
             ./test_reprostim_container.sh
           )
         working-directory: tools/ci

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,6 +44,7 @@ jobs:
         pip install --user --upgrade pip hatch
         hatch env create
         hatch run pip install --upgrade pip
+        hatch run pip install --upgrade "click==8.2.1"
         hatch run pip install pytest pytest-cov reedsolo scipy
       shell: bash
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,14 +42,12 @@ jobs:
         pwd
         ls -l
         echo "- STEP 1"
-        pip install --user --upgrade pip hatch
+        pip install --user "hatch==1.14.1" "click<8.3"
         echo "- STEP 2"
         hatch env create
         echo "- STEP 3"
         hatch run pip install --upgrade pip
         echo "- STEP 4"
-        hatch run pip install --upgrade "click==8.2.1"
-        echo "- STEP 5"
         hatch run pip install pytest pytest-cov reedsolo scipy
       shell: bash
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,10 +41,15 @@ jobs:
       run: |
         pwd
         ls -l
+        echo "- STEP 1"
         pip install --user --upgrade pip hatch
+        echo "- STEP 2"
         hatch env create
+        echo "- STEP 3"
         hatch run pip install --upgrade pip
+        echo "- STEP 4"
         hatch run pip install --upgrade "click==8.2.1"
+        echo "- STEP 5"
         hatch run pip install pytest pytest-cov reedsolo scipy
       shell: bash
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,9 +41,9 @@ jobs:
       run: |
         pwd
         ls -l
-        pip install --upgrade pip
-        pip install hatch
+        pip install --user --upgrade pip hatch
         hatch env create
+        hatch run pip install --upgrade pip
         hatch run pip install pytest pytest-cov reedsolo scipy
       shell: bash
 

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -30,7 +30,7 @@ if [[ "$REPROSTIM_CAPTURE_ENABLED" == "1" ]]; then
   REPROSTIM_CAPTURE_CLEAN="apt-get remove --purge -y $REPROSTIM_CAPTURE_PACKAGES_DEV && apt-get autoremove -y"
   # Extend with packages hold if runtime packages env exist
   if [[ -n "$REPROSTIM_CAPTURE_PACKAGES_RUNTIME" ]]; then
-      REPROSTIM_CAPTURE_CLEAN="apt-mark hold $REPROSTIM_CAPTURE_PACKAGES_RUNTIME && $REPROSTIM_CAPTURE_CLEAN"
+      REPROSTIM_CAPTURE_CLEAN="apt-mark manual $REPROSTIM_CAPTURE_PACKAGES_RUNTIME && apt-mark hold $REPROSTIM_CAPTURE_PACKAGES_RUNTIME && $REPROSTIM_CAPTURE_CLEAN"
   fi
 fi
 

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -78,7 +78,7 @@ generate() {
           libusb-1.0-0-dev portaudio19-dev libasound2-dev pulseaudio pavucontrol pulseaudio-utils \
           vim wget strace time ncdu gnupg curl procps pigz less tree python3 python3-pip \
           "${REPROSTIM_CAPTURE_PACKAGES}" \
-    --run "git clone https://github.com/wieluk/psychopy_linux_installer/ /opt/psychopy-installer; cd /opt/psychopy-installer; git checkout tags/v2.2.1" \
+    --run "git clone https://github.com/wieluk/psychopy_linux_installer/ /opt/psychopy-installer; cd /opt/psychopy-installer; git checkout tags/v2.2.2" \
     --run "/opt/psychopy-installer/psychopy_linux_installer --install-dir=${PSYCHOPY_INSTALL_DIR} --venv-name=${PSYCHOPY_VENV_NAME} --psychopy-version=${PSYCHOPY_VERSION} --additional-packages=psychopy_bids==2025.1.2,psychopy-mri-emulator==0.0.2 --python-version=${PYTHON_VERSION} --wxpython-version=4.2.2 -v -f" \
     ${REPROSTIM_COPY_ARG} \
     --run "${REPROSTIM_RUN_INSTALL}" \

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -32,6 +32,7 @@ if [[ "$REPROSTIM_CAPTURE_ENABLED" == "1" ]]; then
   if [[ -n "$REPROSTIM_CAPTURE_PACKAGES_RUNTIME" ]]; then
       REPROSTIM_CAPTURE_CLEAN="apt-mark manual $REPROSTIM_CAPTURE_PACKAGES_RUNTIME && apt-mark hold $REPROSTIM_CAPTURE_PACKAGES_RUNTIME && $REPROSTIM_CAPTURE_CLEAN"
   fi
+  REPROSTIM_CAPTURE_CLEAN="echo 'ReproStim capture clean is disabled for debug purposes'"
 fi
 
 

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -18,14 +18,16 @@ REPROSTIM_SUFFIX=repronim-reprostim # -${REPROSTIM_VERSION}
 REPROSTIM_GIT_HOME=$(git rev-parse --show-toplevel)
 REPROSTIM_HOME=/opt/reprostim
 REPROSTIM_CAPTURE_ENABLED="${REPROSTIM_CAPTURE_ENABLED:-0}"
-REPROSTIM_CAPTURE_PACKAGES=""
+REPROSTIM_CAPTURE_PACKAGES_DEV=""
+REPROSTIM_CAPTURE_PACKAGES_RUNTIME=""
 REPROSTIM_CAPTURE_BUILD="echo 'ReproStim capture build is disabled'"
 REPROSTIM_CAPTURE_CLEAN="echo 'ReproStim capture clean is disabled'"
 
 if [[ "$REPROSTIM_CAPTURE_ENABLED" == "1" ]]; then
-  REPROSTIM_CAPTURE_PACKAGES="libyaml-cpp-dev libspdlog-dev catch2 libv4l-dev libudev-dev libopencv-dev libcurl4-openssl-dev nlohmann-json3-dev cmake g++"
+  REPROSTIM_CAPTURE_PACKAGES_DEV="libspdlog-dev catch2 libv4l-dev libudev-dev libopencv-dev libcurl4-openssl-dev nlohmann-json3-dev cmake g++"
+  REPROSTIM_CAPTURE_PACKAGES_RUNTIME="libyaml-cpp-dev"
   REPROSTIM_CAPTURE_BUILD="cd \"$REPROSTIM_HOME/src/reprostim-capture\"; mkdir build; cd build; cmake ..; make; cd ..; cmake --install build; rm -rf \"$REPROSTIM_HOME/src/reprostim-capture/build\"; reprostim-videocapture -V"
-  REPROSTIM_CAPTURE_CLEAN="apt-get remove --purge -y $REPROSTIM_CAPTURE_PACKAGES && apt-get autoremove -y"
+  REPROSTIM_CAPTURE_CLEAN="apt-get remove --purge -y $REPROSTIM_CAPTURE_PACKAGES_DEV && apt-get autoremove -y"
 fi
 
 
@@ -77,7 +79,8 @@ generate() {
           libgtk-3-dev libwxgtk3.2-dev libwxgtk-media3.2-dev libwxgtk-webview3.2-dev libcanberra-gtk3-module \
           libusb-1.0-0-dev portaudio19-dev libasound2-dev pulseaudio pavucontrol pulseaudio-utils \
           vim wget strace time ncdu gnupg curl procps pigz less tree python3 python3-pip \
-          "${REPROSTIM_CAPTURE_PACKAGES}" \
+          "${REPROSTIM_CAPTURE_PACKAGES_RUNTIME}" \
+          "${REPROSTIM_CAPTURE_PACKAGES_DEV}" \
     --run "git clone https://github.com/wieluk/psychopy_linux_installer/ /opt/psychopy-installer; cd /opt/psychopy-installer; git checkout tags/v2.2.2" \
     --run "/opt/psychopy-installer/psychopy_linux_installer --install-dir=${PSYCHOPY_INSTALL_DIR} --venv-name=${PSYCHOPY_VENV_NAME} --psychopy-version=${PSYCHOPY_VERSION} --additional-packages=psychopy_bids==2025.1.2,psychopy-mri-emulator==0.0.2 --python-version=${PYTHON_VERSION} --wxpython-version=4.2.2 -v -f" \
     ${REPROSTIM_COPY_ARG} \

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -24,8 +24,8 @@ REPROSTIM_CAPTURE_BUILD="echo 'ReproStim capture build is disabled'"
 REPROSTIM_CAPTURE_CLEAN="echo 'ReproStim capture clean is disabled'"
 
 if [[ "$REPROSTIM_CAPTURE_ENABLED" == "1" ]]; then
-  REPROSTIM_CAPTURE_PACKAGES_DEV="catch2 libv4l-dev libudev-dev libopencv-dev libcurl4-openssl-dev nlohmann-json3-dev cmake g++"
-  REPROSTIM_CAPTURE_PACKAGES_RUNTIME="libyaml-cpp-dev libspdlog-dev"
+  REPROSTIM_CAPTURE_PACKAGES_DEV="libyaml-cpp-dev libspdlog-dev catch2 libv4l-dev libudev-dev libopencv-dev libcurl4-openssl-dev nlohmann-json3-dev cmake g++"
+  REPROSTIM_CAPTURE_PACKAGES_RUNTIME="libyaml-cpp0.7 libfmt9"
   REPROSTIM_CAPTURE_BUILD="cd \"$REPROSTIM_HOME/src/reprostim-capture\"; mkdir build; cd build; cmake ..; make; cd ..; cmake --install build; rm -rf \"$REPROSTIM_HOME/src/reprostim-capture/build\"; reprostim-videocapture -V"
   REPROSTIM_CAPTURE_CLEAN="apt-get remove --purge -y $REPROSTIM_CAPTURE_PACKAGES_DEV && apt-get autoremove -y && apt-get install -y $REPROSTIM_CAPTURE_PACKAGES_RUNTIME"
 fi

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -86,7 +86,7 @@ generate() {
           "${REPROSTIM_CAPTURE_PACKAGES_RUNTIME}" \
           "${REPROSTIM_CAPTURE_PACKAGES_DEV}" \
     --run "git clone https://github.com/wieluk/psychopy_linux_installer/ /opt/psychopy-installer; cd /opt/psychopy-installer; git checkout tags/v2.2.2" \
-    --run "/opt/psychopy-installer/psychopy_linux_installer --install-dir=${PSYCHOPY_INSTALL_DIR} --venv-name=${PSYCHOPY_VENV_NAME} --psychopy-version=${PSYCHOPY_VERSION} --additional-packages=psychopy_bids==2025.1.2,psychopy-mri-emulator==0.0.2 --python-version=${PYTHON_VERSION} --wxpython-version=4.2.2 -v -f" \
+    --run "/opt/psychopy-installer/psychopy_linux_installer --install-dir=${PSYCHOPY_INSTALL_DIR} --venv-name=${PSYCHOPY_VENV_NAME} --psychopy-version=${PSYCHOPY_VERSION} --additional-packages=psychopy_bids==2025.1.2,psychopy-mri-emulator==0.0.2 --python-version=${PYTHON_VERSION} --wxpython-version=4.2.3 -v -f" \
     ${REPROSTIM_COPY_ARG} \
     --run "${REPROSTIM_RUN_INSTALL}" \
     --run "bash -c 'ln -s ${PSYCHOPY_HOME}/start_psychopy /usr/local/bin/psychopy'" \

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -32,7 +32,6 @@ if [[ "$REPROSTIM_CAPTURE_ENABLED" == "1" ]]; then
   if [[ -n "$REPROSTIM_CAPTURE_PACKAGES_RUNTIME" ]]; then
       REPROSTIM_CAPTURE_CLEAN="apt-mark manual $REPROSTIM_CAPTURE_PACKAGES_RUNTIME && apt-mark hold $REPROSTIM_CAPTURE_PACKAGES_RUNTIME && $REPROSTIM_CAPTURE_CLEAN"
   fi
-  REPROSTIM_CAPTURE_CLEAN="echo 'ReproStim capture clean is disabled for debug purposes'"
 fi
 
 

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -27,7 +27,11 @@ if [[ "$REPROSTIM_CAPTURE_ENABLED" == "1" ]]; then
   REPROSTIM_CAPTURE_PACKAGES_DEV="libyaml-cpp-dev libspdlog-dev catch2 libv4l-dev libudev-dev libopencv-dev libcurl4-openssl-dev nlohmann-json3-dev cmake g++"
   REPROSTIM_CAPTURE_PACKAGES_RUNTIME="libyaml-cpp0.7 libfmt9"
   REPROSTIM_CAPTURE_BUILD="cd \"$REPROSTIM_HOME/src/reprostim-capture\"; mkdir build; cd build; cmake ..; make; cd ..; cmake --install build; rm -rf \"$REPROSTIM_HOME/src/reprostim-capture/build\"; reprostim-videocapture -V"
-  REPROSTIM_CAPTURE_CLEAN="apt-get remove --purge -y $REPROSTIM_CAPTURE_PACKAGES_DEV && apt-get autoremove -y && apt-get install -y $REPROSTIM_CAPTURE_PACKAGES_RUNTIME"
+  REPROSTIM_CAPTURE_CLEAN="apt-get remove --purge -y $REPROSTIM_CAPTURE_PACKAGES_DEV && apt-get autoremove -y"
+  # Extend with packages hold if runtime packages env exist
+  if [[ -n "$REPROSTIM_CAPTURE_PACKAGES_RUNTIME" ]]; then
+      REPROSTIM_CAPTURE_CLEAN="apt-mark hold $REPROSTIM_CAPTURE_PACKAGES_RUNTIME && $REPROSTIM_CAPTURE_CLEAN"
+  fi
 fi
 
 

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -24,8 +24,8 @@ REPROSTIM_CAPTURE_BUILD="echo 'ReproStim capture build is disabled'"
 REPROSTIM_CAPTURE_CLEAN="echo 'ReproStim capture clean is disabled'"
 
 if [[ "$REPROSTIM_CAPTURE_ENABLED" == "1" ]]; then
-  REPROSTIM_CAPTURE_PACKAGES_DEV="libspdlog-dev catch2 libv4l-dev libudev-dev libopencv-dev libcurl4-openssl-dev nlohmann-json3-dev cmake g++"
-  REPROSTIM_CAPTURE_PACKAGES_RUNTIME="libyaml-cpp-dev"
+  REPROSTIM_CAPTURE_PACKAGES_DEV="catch2 libv4l-dev libudev-dev libopencv-dev libcurl4-openssl-dev nlohmann-json3-dev cmake g++"
+  REPROSTIM_CAPTURE_PACKAGES_RUNTIME="libyaml-cpp-dev libspdlog-dev"
   REPROSTIM_CAPTURE_BUILD="cd \"$REPROSTIM_HOME/src/reprostim-capture\"; mkdir build; cd build; cmake ..; make; cd ..; cmake --install build; rm -rf \"$REPROSTIM_HOME/src/reprostim-capture/build\"; reprostim-videocapture -V"
   REPROSTIM_CAPTURE_CLEAN="apt-get remove --purge -y $REPROSTIM_CAPTURE_PACKAGES_DEV && apt-get autoremove -y"
 fi

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -27,7 +27,7 @@ if [[ "$REPROSTIM_CAPTURE_ENABLED" == "1" ]]; then
   REPROSTIM_CAPTURE_PACKAGES_DEV="catch2 libv4l-dev libudev-dev libopencv-dev libcurl4-openssl-dev nlohmann-json3-dev cmake g++"
   REPROSTIM_CAPTURE_PACKAGES_RUNTIME="libyaml-cpp-dev libspdlog-dev"
   REPROSTIM_CAPTURE_BUILD="cd \"$REPROSTIM_HOME/src/reprostim-capture\"; mkdir build; cd build; cmake ..; make; cd ..; cmake --install build; rm -rf \"$REPROSTIM_HOME/src/reprostim-capture/build\"; reprostim-videocapture -V"
-  REPROSTIM_CAPTURE_CLEAN="apt-get remove --purge -y $REPROSTIM_CAPTURE_PACKAGES_DEV && apt-get autoremove -y"
+  REPROSTIM_CAPTURE_CLEAN="apt-get remove --purge -y $REPROSTIM_CAPTURE_PACKAGES_DEV && apt-get autoremove -y && apt-get install -y $REPROSTIM_CAPTURE_RUNTIME_PACKAGES"
 fi
 
 

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -6,7 +6,7 @@ thisdir=$(dirname "$0")
 
 PYTHON_VERSION=3.10
 
-PSYCHOPY_VERSION=2024.2.5
+PSYCHOPY_VERSION=2025.2.0
 PSYCHOPY_INSTALL_DIR=/opt/psychopy
 PSYCHOPY_VENV_NAME=psychopy_${PSYCHOPY_VERSION}_py${PYTHON_VERSION}
 PSYCHOPY_HOME=${PSYCHOPY_INSTALL_DIR}/${PSYCHOPY_VENV_NAME}
@@ -79,7 +79,7 @@ generate() {
           vim wget strace time ncdu gnupg curl procps pigz less tree python3 python3-pip \
           "${REPROSTIM_CAPTURE_PACKAGES}" \
     --run "git clone https://github.com/wieluk/psychopy_linux_installer/ /opt/psychopy-installer; cd /opt/psychopy-installer; git checkout tags/v2.2.1" \
-    --run "/opt/psychopy-installer/psychopy_linux_installer --install-dir=${PSYCHOPY_INSTALL_DIR} --venv-name=${PSYCHOPY_VENV_NAME} --psychopy-version=${PSYCHOPY_VERSION} --additional-packages=psychopy_bids==2024.2.2,psychopy-mri-emulator==0.0.2 --python-version=${PYTHON_VERSION} --wxpython-version=4.2.2 -v -f" \
+    --run "/opt/psychopy-installer/psychopy_linux_installer --install-dir=${PSYCHOPY_INSTALL_DIR} --venv-name=${PSYCHOPY_VENV_NAME} --psychopy-version=${PSYCHOPY_VERSION} --additional-packages=psychopy_bids==2025.1.2,psychopy-mri-emulator==0.0.2 --python-version=${PYTHON_VERSION} --wxpython-version=4.2.2 -v -f" \
     ${REPROSTIM_COPY_ARG} \
     --run "${REPROSTIM_RUN_INSTALL}" \
     --run "bash -c 'ln -s ${PSYCHOPY_HOME}/start_psychopy /usr/local/bin/psychopy'" \

--- a/containers/repronim-reprostim/generate_container.sh
+++ b/containers/repronim-reprostim/generate_container.sh
@@ -27,7 +27,7 @@ if [[ "$REPROSTIM_CAPTURE_ENABLED" == "1" ]]; then
   REPROSTIM_CAPTURE_PACKAGES_DEV="catch2 libv4l-dev libudev-dev libopencv-dev libcurl4-openssl-dev nlohmann-json3-dev cmake g++"
   REPROSTIM_CAPTURE_PACKAGES_RUNTIME="libyaml-cpp-dev libspdlog-dev"
   REPROSTIM_CAPTURE_BUILD="cd \"$REPROSTIM_HOME/src/reprostim-capture\"; mkdir build; cd build; cmake ..; make; cd ..; cmake --install build; rm -rf \"$REPROSTIM_HOME/src/reprostim-capture/build\"; reprostim-videocapture -V"
-  REPROSTIM_CAPTURE_CLEAN="apt-get remove --purge -y $REPROSTIM_CAPTURE_PACKAGES_DEV && apt-get autoremove -y && apt-get install -y $REPROSTIM_CAPTURE_RUNTIME_PACKAGES"
+  REPROSTIM_CAPTURE_CLEAN="apt-get remove --purge -y $REPROSTIM_CAPTURE_PACKAGES_DEV && apt-get autoremove -y && apt-get install -y $REPROSTIM_CAPTURE_PACKAGES_RUNTIME"
 fi
 
 

--- a/containers/repronim-reprostim/run_reprostim_ci.sh
+++ b/containers/repronim-reprostim/run_reprostim_ci.sh
@@ -15,13 +15,13 @@ REPROSTIM_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.1")
 # REPROSTIM_OVERLAY=--overlay ./repronim-reprostim-${REPROSTIM_VERSION}.overlay
 REPROSTIM_OVERLAY=
 if [[ "$REPROSTIM_CONTAINER_TYPE" == "docker" ]]; then
-  REPROSTIM_CONTAINER_IMAGE="repronim/reprostim:${REPROSTIM_VERSION}"
+  REPROSTIM_CONTAINER_IMAGE="${REPROSTIM_CONTAINER_IMAGE:-repronim/reprostim:${REPROSTIM_VERSION}}"
   DOCKER_TTY=""
   if [ -t 1 ]; then
     DOCKER_TTY="-t"
   fi
 elif [[ "$REPROSTIM_CONTAINER_TYPE" == "singularity" ]]; then
-  REPROSTIM_CONTAINER_IMAGE="./repronim-reprostim-${REPROSTIM_VERSION}.sing"
+  REPROSTIM_CONTAINER_IMAGE="${REPROSTIM_CONTAINER_IMAGE:-./repronim-reprostim-${REPROSTIM_VERSION}.sing}"
 fi
 
 # Calculate entry point

--- a/containers/repronim-reprostim/run_reprostim_ci.sh
+++ b/containers/repronim-reprostim/run_reprostim_ci.sh
@@ -6,6 +6,7 @@
 #
 
 REPROSTIM_CONTAINER_TYPE="${REPROSTIM_CONTAINER_TYPE:-singularity}"
+REPROSTIM_CONTAINER_RUN_MODE="${REPROSTIM_CONTAINER_RUN_MODE:-reprostim}"
 
 export REPROSTIM_PATH="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -21,6 +22,17 @@ if [[ "$REPROSTIM_CONTAINER_TYPE" == "docker" ]]; then
   fi
 elif [[ "$REPROSTIM_CONTAINER_TYPE" == "singularity" ]]; then
   REPROSTIM_CONTAINER_IMAGE="./repronim-reprostim-${REPROSTIM_VERSION}.sing"
+fi
+
+# Calculate entry point
+if [ "$REPROSTIM_CONTAINER_RUN_MODE" = "reprostim-videocapture" ]; then
+    REPROSTIM_CONTAINER_ENTRY_POINT="reprostim-videocapture"
+elif [ "$REPROSTIM_CONTAINER_TYPE" = "docker" ]; then
+    REPROSTIM_CONTAINER_ENTRY_POINT="-m reprostim"
+elif [ "$REPROSTIM_CONTAINER_TYPE" = "singularity" ]; then
+    REPROSTIM_CONTAINER_ENTRY_POINT="python3 -m reprostim"
+else
+    REPROSTIM_CONTAINER_ENTRY_POINT="-m reprostim"
 fi
 
 
@@ -43,7 +55,7 @@ if [[ "$REPROSTIM_CONTAINER_TYPE" == "docker" ]]; then
     -w "${REPROSTIM_PATH}" \
     --env DISPLAY=$DISPLAY \
     ${REPROSTIM_OVERLAY} ${REPROSTIM_CONTAINER_IMAGE} \
-    -m reprostim $@
+    ${REPROSTIM_CONTAINER_ENTRY_POINT} $@
 elif [[ "$REPROSTIM_CONTAINER_TYPE" == "singularity" ]]; then
   singularity exec \
     --cleanenv --contain \
@@ -51,7 +63,7 @@ elif [[ "$REPROSTIM_CONTAINER_TYPE" == "singularity" ]]; then
     -B ${REPROSTIM_PATH} \
     --env DISPLAY=$DISPLAY \
     ${REPROSTIM_OVERLAY} ${REPROSTIM_CONTAINER_IMAGE} \
-    python3 -m reprostim $@
+    ${REPROSTIM_CONTAINER_ENTRY_POINT} $@
 else
   log "Unknown REPROSTIM_CONTAINER_TYPE: ${REPROSTIM_CONTAINER_TYPE}"
   exit 1

--- a/containers/repronim-reprostim/run_reprostim_ci.sh
+++ b/containers/repronim-reprostim/run_reprostim_ci.sh
@@ -26,7 +26,7 @@ fi
 
 # Calculate entry point
 if [ "$REPROSTIM_CONTAINER_RUN_MODE" = "reprostim-videocapture" ]; then
-    REPROSTIM_CONTAINER_ENTRY_POINT="reprostim-videocapture"
+    REPROSTIM_CONTAINER_ENTRY_POINT="/usr/local/bin/reprostim-videocapture"
 elif [ "$REPROSTIM_CONTAINER_TYPE" = "docker" ]; then
     REPROSTIM_CONTAINER_ENTRY_POINT="-m reprostim"
 elif [ "$REPROSTIM_CONTAINER_TYPE" = "singularity" ]; then

--- a/containers/repronim-reprostim/run_reprostim_ci.sh
+++ b/containers/repronim-reprostim/run_reprostim_ci.sh
@@ -25,14 +25,18 @@ elif [[ "$REPROSTIM_CONTAINER_TYPE" == "singularity" ]]; then
 fi
 
 # Calculate entry point
+REPROSTIM_CONTAINER_ENTRYPOINT=""
 if [ "$REPROSTIM_CONTAINER_RUN_MODE" = "reprostim-videocapture" ]; then
-    REPROSTIM_CONTAINER_ENTRY_POINT="/usr/local/bin/reprostim-videocapture"
+    REPROSTIM_CONTAINER_APP="reprostim-videocapture"
+    if [ "$REPROSTIM_CONTAINER_TYPE" = "docker" ]; then
+        REPROSTIM_CONTAINER_ENTRYPOINT="--entrypoint="
+    fi
 elif [ "$REPROSTIM_CONTAINER_TYPE" = "docker" ]; then
-    REPROSTIM_CONTAINER_ENTRY_POINT="-m reprostim"
+    REPROSTIM_CONTAINER_APP="-m reprostim"
 elif [ "$REPROSTIM_CONTAINER_TYPE" = "singularity" ]; then
-    REPROSTIM_CONTAINER_ENTRY_POINT="python3 -m reprostim"
+    REPROSTIM_CONTAINER_APP="python3 -m reprostim"
 else
-    REPROSTIM_CONTAINER_ENTRY_POINT="-m reprostim"
+    REPROSTIM_CONTAINER_APP="-m reprostim"
 fi
 
 
@@ -46,16 +50,17 @@ log "Run ReproStim ${REPROSTIM_CONTAINER_TYPE} CI/CD Container v${REPROSTIM_VERS
 log "  [REPROSTIM_PATH] : ${REPROSTIM_PATH}"
 log "  [IMAGE]          : ${REPROSTIM_CONTAINER_IMAGE}"
 log "  [OVERLAY]        : ${REPROSTIM_OVERLAY}"
-log "  [ARGS]           : $@"
+log "  [ARGS]           : $*"
 
 
 if [[ "$REPROSTIM_CONTAINER_TYPE" == "docker" ]]; then
   docker run --rm -i ${DOCKER_TTY} \
+    ${REPROSTIM_CONTAINER_ENTRYPOINT} \
     -v "${REPROSTIM_PATH}:${REPROSTIM_PATH}" \
     -w "${REPROSTIM_PATH}" \
     --env DISPLAY=$DISPLAY \
     ${REPROSTIM_OVERLAY} ${REPROSTIM_CONTAINER_IMAGE} \
-    ${REPROSTIM_CONTAINER_ENTRY_POINT} $@
+    ${REPROSTIM_CONTAINER_APP} "$@"
 elif [[ "$REPROSTIM_CONTAINER_TYPE" == "singularity" ]]; then
   singularity exec \
     --cleanenv --contain \
@@ -63,7 +68,7 @@ elif [[ "$REPROSTIM_CONTAINER_TYPE" == "singularity" ]]; then
     -B ${REPROSTIM_PATH} \
     --env DISPLAY=$DISPLAY \
     ${REPROSTIM_OVERLAY} ${REPROSTIM_CONTAINER_IMAGE} \
-    ${REPROSTIM_CONTAINER_ENTRY_POINT} $@
+    ${REPROSTIM_CONTAINER_APP} "$@"
 else
   log "Unknown REPROSTIM_CONTAINER_TYPE: ${REPROSTIM_CONTAINER_TYPE}"
   exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "click>=8.1.7",
+  "click>=8.1.7,<8.2.2",
   "click-didyoumean>=0.3.1",
   "pydantic>=2.7.1",
   "numpy>=1.26.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "click>=8.1.7,<8.2.2",
+  "click==8.2.1",
   "click-didyoumean>=0.3.1",
   "pydantic>=2.7.1",
   "numpy>=1.26.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "click==8.2.1",
+  "click>=8.1.7",
   "click-didyoumean>=0.3.1",
   "pydantic>=2.7.1",
   "numpy>=1.26.4",

--- a/tools/ci/test_reprostim_container.sh
+++ b/tools/ci/test_reprostim_container.sh
@@ -8,8 +8,15 @@ echo "Test CI/CD containers for ReproStim.."
 
 cd ${thisdir}
 echo Test reprostim --version
+export REPROSTIM_CONTAINER_RUN_MODE="reprostim"
 ./run_reprostim_container.sh --version
 
 cd ${thisdir}
 echo Test reprostim --help
+export REPROSTIM_CONTAINER_RUN_MODE="reprostim"
+./run_reprostim_container.sh --help
+
+cd ${thisdir}
+echo Test reprostim-videocapture --help
+export REPROSTIM_CONTAINER_RUN_MODE="reprostim-videocapture"
 ./run_reprostim_container.sh --help


### PR DESCRIPTION
In continuation to #174, upgrade PsychoPy to the latest available version. Provide also fix for docker/singularity containers as well.

**Tasks:**
- [x] Upgrade `PsychoPy` to 2025.2.0.
  - #175
- [x] Upgrade `psychopy_linux_installer` to 4.2.2.
- [x] Upgrade `wxPython` to 4.2.3.
- [x] Fix `PyTest` workflow action error caused by hatch 1.4.1/click 8.3 incompatibility.
- [x] Include `reprostim-videocapture --help` test into container tests for docker/singularity.
- [x] Fix missing `reprostim-videocapture` dependencies in docker/singularity containers by spliting it into runtime and dev groups.  
  - #184
- [x] Fix docker workflow action tests issue, where docker image for tests was downloaded from dockerhub (some previous version) rather than using current local build. 

Closes #175 
Closes #184