### PR TITLE
Fix `video-audit` `qr` processing issues

### DIFF
--- a/src/reprostim/qr/video_audit.py
+++ b/src/reprostim/qr/video_audit.py
@@ -1041,6 +1041,10 @@ def run_ext_qr(ctx: VaContext, vr: VaRecord) -> VaRecord:
                 tmp_video: str = os.path.join(tmpdir, base_name)
                 logger.debug(f"tmp_video : {tmp_video}")
 
+                # set default value first to prevent stale n/a data for ffmpeg
+                vr.qr_records_number = "-2"
+                _set_updated(ctx, vr, field="qr_updated_on")
+
                 try:
                     # convert to mkv without audio
                     # like: ffmpeg -i "$file" -an -c copy "$tmp_mkv_file"
@@ -1095,7 +1099,7 @@ def run_ext_qr(ctx: VaContext, vr: VaRecord) -> VaRecord:
                             )
                             logger.debug(f"qr-parse completed with return code {result.returncode}")
 
-                    # set default value first to prevent stale n/a data
+                    # set default value first to prevent stale n/a data for qr-parse
                     vr.qr_records_number = "-1"
                     _set_updated(ctx, vr, field="qr_updated_on")
 


### PR DESCRIPTION
When invoking `video-audit` `qr` tool over all dataset found cases when `qr_records_number` and timestamps are not updated when:

- [x] file name is invalid and doesn't match any pattern like `2024.01.29.17.10.23.697_.mkv`
- [x] .mkv file has invalid content, and `ffmpeg` fails with error `2024.01.30.08.30.33.449_2024.01.30.08.30.39.558.mkv`
- [x] create new release and deploy it to `typhon` and rerun qr cron job.

This kind of functionality prevents `qr` cron job to fetch any new records, and all time it processes the same files. `qr_records_number` set  to `-2` when ffmpeg fails and to `-1` when `qr-parse` commands fail.

