### PR TITLE
Extend `video-audit` with custom opts for external tools and apply them to `typhon`

### DIFF
--- a/.ai/context.md
+++ b/.ai/context.md
@@ -37,7 +37,7 @@ Main Python package with CLI tools and analysis utilities.
   - `cmd_detect_noscreen.py` - Detect no-signal/rainbow frames with fixup capabilities
   - `cmd_list_displays.py` - List available GUI displays (cross-platform)
   - `cmd_monitor_displays.py` - Monitor display connection status with callbacks
-  - `cmd_video_audit.py` - Comprehensive video analysis (incremental/full/force modes)
+  - `cmd_video_audit.py` - Comprehensive video analysis (incremental/full/force modes) (see [spec-video-audit.md](spec-video-audit.md), [task-video-audit.md](task-video-audit.md))
   - `cmd_split_video.py` - Split/slice videos to specific time ranges (see [spec-split-video.md](.ai/spec-split-video.md))
   - `cmd_bids_inject.py` - Inject sliced videos into a BIDS dataset aligned to scan timing (see [spec-bids-inject.md](.ai/spec-bids-inject.md))
   - `cmd_echo.py` - Simple echo command for testing
@@ -47,7 +47,7 @@ Main Python package with CLI tools and analysis utilities.
   - `timesync_stimuli.py` - PsychoPy-based MRI/BIRCH/Magewell synchronization
   - `disp_mon.py` - Cross-platform display monitoring (Linux/macOS/Windows)
   - `psychopy.py` - PsychoPy framework integration utilities
-  - `video_audit.py` - Comprehensive video analysis with multiple audit sources
+  - `video_audit.py` - Comprehensive video analysis with multiple audit sources (see [spec-video-audit.md](spec-video-audit.md), [task-video-audit.md](task-video-audit.md))
   - `split_video.py` - Video slicing/splitting functionality (see [spec-split-video.md](.ai/spec-split-video.md))
   - `bids_inject.py` - BIDS dataset injection logic (see [spec-bids-inject.md](.ai/spec-bids-inject.md))
 

--- a/.ai/spec-video-audit.md
+++ b/.ai/spec-video-audit.md
@@ -1,0 +1,221 @@
+# Video Audit Tool Specification
+
+## Overview
+
+`video-audit` analyzes video files recorded by `reprostim-videocapture`, along with their
+corresponding `.log` sidecar files and QR/audio metadata. It extracts key information about
+each recording and produces a summary table (`videos.tsv`) suitable for quality control,
+sharing, and further analysis.
+
+The tool operates in a pipeline of up to three audit sources:
+
+1. **INTERNAL** — fast pass using `mediainfo`/ffprobe and `.log` sidecars; always runs first
+2. **NOSIGNAL** — slow pass using `reprostim detect-noscreen` to measure no-signal frame rate
+3. **QR** — very slow pass using `reprostim qr-parse` to count detected QR records per video
+
+Results are accumulated into a TSV file (`videos.tsv`) with timestamp-aware merging so that
+incremental updates from different sources are combined correctly.
+
+---
+
+## CLI Interface
+
+```
+reprostim video-audit [OPTIONS] [PATHS]...
+```
+
+### Arguments
+
+| Argument  | Description                                                                     |
+|-----------|---------------------------------------------------------------------------------|
+| `PATHS`   | One or more paths to video files (`.mkv`, `.mp4`, `.avi`) or directories. Required. |
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `-m / --mode` | Choice | `incremental` | Operation mode (see [Modes](#modes)) |
+| `-o / --output` | Path | `videos.tsv` | Output TSV file |
+| `-r / --recursive` | Flag | `False` | Recursively scan subdirectories |
+| `-s / --audit-src` | Choice (repeatable) | `internal` | Audit source(s) to run (see [Sources](#audit-sources)) |
+| `-l / --max-files` | Int | `-1` | Max number of files/records to process; `-1` = unlimited |
+| `-p / --path-mask` | Str | `None` | fnmatch-style filter on file paths |
+| `-v / --verbose` | Flag | `False` | Print each record as JSON to stdout |
+| `--nosignal-opts` | Str | `None` | Override default options passed to `detect-noscreen` (shlex-parsed string); uses built-in defaults when omitted |
+| `--qr-opts` | Str | `None` | Extra options passed to `qr-parse` (shlex-parsed string); uses built-in defaults when omitted |
+
+### Example invocations
+
+```shell
+# Incremental audit of a directory (INTERNAL only, fast)
+reprostim video-audit /data/recordings/
+
+# Full re-audit including QR and nosignal sources
+reprostim video-audit --mode full -s all /data/recordings/ -o videos.tsv
+
+# Recursive scan, incremental, QR only
+reprostim video-audit -r -s qr /data/recordings/
+
+# Rerun only nosignal for records that currently show n/a
+reprostim video-audit --mode rerun-for-na -s nosignal /data/recordings/
+
+# Reset QR results to n/a (to force a clean rerun later)
+reprostim video-audit --mode reset-to-na -s qr /data/recordings/
+
+# Limit to first 5 files, verbose JSON output
+reprostim video-audit -l 5 -v /data/recordings/
+
+# Override detect-noscreen parameters
+reprostim video-audit -s nosignal \
+  --nosignal-opts "--number-of-checks 200 --threshold 0.9" \
+  /data/recordings/
+
+# Pass extra options to qr-parse
+reprostim video-audit -s qr \
+  --qr-opts "--skip 2 --std-threshold 15" \
+  /data/recordings/
+```
+
+---
+
+## Modes
+
+| Mode | Description |
+|------|-------------|
+| `incremental` | Process only new files not present in the existing TSV; merge results |
+| `full` | Regenerate all records from scratch, overwrite existing TSV completely |
+| `force` | Redo/overwrite existing records for the specified files |
+| `rerun-for-na` | Re-run external tools only for records whose related fields are `n/a` |
+| `reset-to-na` | Reset external-tool fields (`no_signal_frames`, `qr_records_number`) to `n/a` |
+
+---
+
+## Audit Sources
+
+| Source | Speed | Description |
+|--------|-------|-------------|
+| `internal` | Fast | Uses ffprobe + `.log` sidecar; extracts timestamps, resolution, FPS, audio, duration |
+| `nosignal` | Slow | Runs `reprostim detect-noscreen`; stores `nosignal_rate` as a percentage |
+| `qr` | Very slow | Runs `reprostim qr-parse` via ffmpeg-stripped temp copy; stores `qr_count` |
+| `all` | — | Runs all three sources above |
+
+Sources can be combined: `-s internal -s qr` runs both INTERNAL and QR passes.
+
+---
+
+## Output: `videos.tsv`
+
+Tab-separated file. One row per video file, columns defined by `VaRecord`:
+
+| Column | Description |
+|--------|-------------|
+| `path` | Absolute path to the `.mkv` file |
+| `present` | Whether the file exists on disk |
+| `complete` | Whether end timestamp is present in log |
+| `name` | Short base name (used as merge key) |
+| `start_date` / `start_time` | Recording start (`YYYY-MM-DD`, `HH:MM:SS.mmm`) |
+| `end_date` / `end_time` | Recording end (`YYYY-MM-DD`, `HH:MM:SS.mmm`) |
+| `video_res_detected` | Resolution from `session_begin` log entry, e.g. `1920x1080` |
+| `video_fps_detected` | FPS from `session_begin` log entry |
+| `video_dur_detected` | Duration from mediainfo (seconds) |
+| `video_res_recorded` | Resolution from `qr_parse.do_parse` |
+| `video_fps_recorded` | FPS from `qr_parse.do_parse` |
+| `video_dur_recorded` | Duration from `qr_parse.do_parse` (seconds) |
+| `video_size_mb` | File size in MB |
+| `video_rate_mbpm` | Bitrate in MB/min |
+| `audio_sr` | Audio sample rate + bit depth + channels + codec |
+| `audio_dur` | Audio stream duration (seconds) |
+| `duration` | Best-available duration (seconds) |
+| `duration_h` | Human-readable duration (`HH:MM:SS.mmm`) |
+| `no_signal_frames` | No-signal percentage from `detect-noscreen`, or `n/a` |
+| `qr_records_number` | QR record count from `qr-parse`, or `n/a` |
+| `file_log_coherent` | Whether video/audio metadata is internally consistent |
+| `no_signal_updated_on` | Timestamp of last nosignal update |
+| `qr_updated_on` | Timestamp of last QR update |
+| `updated_on` | Timestamp of last INTERNAL update |
+
+Sentinel values for `qr_records_number`:
+- `n/a` — not yet processed
+- `-2` — ffmpeg conversion started but qr-parse not yet invoked
+- `-1` — qr-parse completed but no `ParseSummary` record found in output
+- `≥ 0` — actual QR record count
+
+---
+
+## Derived Output Files
+
+### NOSIGNAL data
+- JSON output: `derivatives/nosignal/<YYYY>/<MM>/<basename>.nosignal.json`
+- Log output: `logs/nosignal/<YYYY>/<MM>/<basename>.nosignal.log`
+- Directories configurable via `VaContext.nosignal_data_dir` / `nosignal_log_dir`
+
+### QR data
+- JSONL output: `derivatives/qr/<YYYY>/<MM>/<basename>.qrinfo.jsonl`
+- Log output: `logs/qr/<YYYY>/<MM>/<basename>.qrinfo.log`
+- ffmpeg log: `logs/qr/<YYYY>/<MM>/<basename>.ffmpeg.log`
+- Directories configurable via `VaContext.qr_data_dir` / `qr_log_dir`
+
+---
+
+## Concurrency and Locking
+
+- `videos.tsv` is protected by a `filelock.FileLock` (`videos.tsv.lock`) during all reads and writes.
+- Each video file gets per-source lock files (`.nosignal.lock`, `.qr.lock`) to prevent concurrent
+  processing of the same file by multiple processes.
+- `_get_tsv_records` supports a `use_lock=False` dirty-read mode for callers that cannot acquire
+  the lock (e.g. different OS user) — used by `bids-inject`.
+
+---
+
+## Merge Strategy
+
+The TSV is updated using a three-way timestamp-aware merge:
+
+- `updated_on` — controls which process wrote the INTERNAL fields
+- `no_signal_updated_on` — controls which process wrote `no_signal_frames`
+- `qr_updated_on` — controls which process wrote `qr_records_number`
+
+When a record exists in both the current TSV and the new batch, `_merge_rec` picks the
+**newest** value for each group of fields independently, allowing INTERNAL, NOSIGNAL, and QR
+results from separate runs to coexist correctly.
+
+---
+
+## Python API
+
+Key public symbols in `reprostim.qr.video_audit`:
+
+| Symbol | Type | Description |
+|--------|------|-------------|
+| `VaRecord` | Pydantic model | Single TSV row |
+| `VaContext` | Pydantic model | All processing options including `nosignal_opts`, `qr_opts` |
+| `VaMode` | Enum | Operation modes |
+| `VaSource` | Enum | Audit sources |
+| `do_audit_file` | Generator | Audit a single video file (INTERNAL) |
+| `do_audit_dir` | Generator | Audit all videos in a directory |
+| `do_audit` | Generator | Full pipeline (INTERNAL + external) |
+| `do_ext` | Generator | External-only pass over existing records |
+| `do_main` | Function | CLI entry point; accepts `nosignal_opts` and `qr_opts` as shlex strings |
+| `get_file_video_audit` | Function | Look up a single file (TSV cache or live audit) |
+| `find_video_audit_by_timerange` | Function | Intersect-based lookup used by `bids-inject` |
+
+---
+
+## Dependencies
+
+- **ffprobe** (`ffmpeg` package) — required for audio stream extraction
+- **mediainfo** — used internally via `qr_parse.do_info_file`
+- **reprostim detect-noscreen** — required for NOSIGNAL source
+- **reprostim qr-parse** — required for QR source
+- **ffmpeg** — required for QR source (audio stripping before qr-parse)
+- **filelock** — advisory locking for TSV and per-file operations
+
+---
+
+## Open Questions / Future Work
+
+- **Parallel processing** — `--jobs` option for concurrent file processing
+- **Config file** — TOML/YAML support for `nosignal_opts` / `qr_opts` defaults
+- **Progress reporting** — tqdm progress bar for large directories
+- **DataLad integration** — auto-`datalad save` after TSV update
+- **`--columns` filter** — select which TSV columns to populate per run

--- a/.ai/spec-video-audit.md
+++ b/.ai/spec-video-audit.md
@@ -41,8 +41,9 @@ reprostim video-audit [OPTIONS] [PATHS]...
 | `-l / --max-files` | Int | `-1` | Max number of files/records to process; `-1` = unlimited |
 | `-p / --path-mask` | Str | `None` | fnmatch-style filter on file paths |
 | `-v / --verbose` | Flag | `False` | Print each record as JSON to stdout |
-| `--nosignal-opts` | Str | `None` | Override default options passed to `detect-noscreen` (shlex-parsed string); uses built-in defaults when omitted |
-| `--qr-opts` | Str | `None` | Extra options passed to `qr-parse` (shlex-parsed string); uses built-in defaults when omitted |
+| `-n / --nosignal-opts` | Str | `None` | Override default options passed to `detect-noscreen` (shlex-parsed string); uses built-in defaults when omitted |
+| `-q / --qr-opts` | Str | `None` | Extra options passed to `qr-parse` (shlex-parsed string); no extra options by default |
+| `-c / --config` | Path | `None` | Optional YAML config file; provides defaults for any option not set on the CLI (see [Config File](#config-file)) |
 
 ### Example invocations
 
@@ -72,9 +73,38 @@ reprostim video-audit -s nosignal \
 
 # Pass extra options to qr-parse
 reprostim video-audit -s qr \
-  --qr-opts "--skip 2 --std-threshold 15" \
+  -q "--skip 2 --std-threshold 15" \
   /data/recordings/
+
+# Use a YAML config file for defaults, override one option on the CLI
+reprostim video-audit -c audit.yaml -s nosignal /data/recordings/
 ```
+
+---
+
+## Config File
+
+`-c / --config` accepts an optional path to a YAML file. Values in the config file act as
+defaults — any option explicitly passed on the CLI takes precedence.
+
+Keys mirror the CLI long option names (hyphens, no leading `--`). Supported keys:
+
+```yaml
+# audit.yaml — example config
+mode: incremental
+output: videos.tsv
+recursive: false
+audit-src:
+  - internal
+  - qr
+max-files: -1
+path-mask: null
+verbose: false
+nosignal-opts: "--number-of-checks 200 --threshold 0.9"
+qr-opts: "--skip 2 --std-threshold 15"
+```
+
+Precedence (lowest → highest): built-in CLI defaults → config file → explicit CLI flags.
 
 ---
 
@@ -215,7 +245,6 @@ Key public symbols in `reprostim.qr.video_audit`:
 ## Open Questions / Future Work
 
 - **Parallel processing** — `--jobs` option for concurrent file processing
-- **Config file** — TOML/YAML support for `nosignal_opts` / `qr_opts` defaults
 - **Progress reporting** — tqdm progress bar for large directories
 - **DataLad integration** — auto-`datalad save` after TSV update
 - **`--columns` filter** — select which TSV columns to populate per run

--- a/.ai/task-video-audit.md
+++ b/.ai/task-video-audit.md
@@ -14,8 +14,11 @@ Tracks implementation progress against [spec-video-audit.md](spec-video-audit.md
 - [x] `-l / --max-files` — limit number of records processed
 - [x] `-p / --path-mask` — fnmatch-style filter on file paths
 - [x] `-v / --verbose` — print JSON records to stdout
-- [ ] `--nosignal-opts` — override detect-noscreen options (shlex string)
-- [ ] `--qr-opts` — override qr-parse options (shlex string)
+- [x] `-n / --nosignal-opts` — override detect-noscreen options (shlex string)
+- [x] `-q / --qr-opts` — override qr-parse options (shlex string)
+- [ ] Add short forms `-n` and `-q` to existing `--nosignal-opts` / `--qr-opts` in CLI code
+- [ ] `-c / --config` — optional YAML config file with CLI-override precedence
+- [ ] Add `pyyaml>=6.0` to `pyproject.toml` dependencies
 
 ---
 
@@ -43,8 +46,8 @@ Tracks implementation progress against [spec-video-audit.md](spec-video-audit.md
 - [x] Store log output under dated path in `nosignal_log_dir`
 - [x] Parse `nosignal_rate` from JSON and store as percentage
 - [x] Per-file lock (`.nosignal.lock`) to prevent concurrent runs
-- [ ] Pass `nosignal_opts` to detect-noscreen via `VaContext`
-- [ ] Accept `--nosignal-opts` override from CLI (shlex-parsed)
+- [x] Pass `nosignal_opts` to detect-noscreen via `VaContext`
+- [x] Accept `--nosignal-opts` override from CLI (shlex-parsed)
 
 ### External audit — QR (`VaSource.QR`)
 - [x] Convert video to audio-free copy via ffmpeg (temp dir)
@@ -53,8 +56,8 @@ Tracks implementation progress against [spec-video-audit.md](spec-video-audit.md
 - [x] Store log output under dated path in `qr_log_dir`
 - [x] Parse `ParseSummary.qr_count` from JSONL output
 - [x] Per-file lock (`.qr.lock`) to prevent concurrent runs
-- [ ] Pass `qr_opts` to qr-parse via `VaContext`
-- [ ] Accept `--qr-opts` override from CLI (shlex-parsed)
+- [x] Pass `qr_opts` to qr-parse via `VaContext`
+- [x] Accept `--qr-opts` override from CLI (shlex-parsed)
 
 ### Operation modes (`VaMode`)
 - [x] `full` — regenerate all records from scratch
@@ -118,10 +121,14 @@ Test file location: `tests/qr/test_video_audit.py`
 ### CLI tests (Click `CliRunner`)
 
 - [ ] `--help` renders without error
-- [ ] `--nosignal-opts` string parsed and forwarded to `VaContext.nosignal_opts`
-- [ ] `--qr-opts` string parsed and forwarded to `VaContext.qr_opts`
-- [ ] Omitting `--nosignal-opts` → `VaContext` uses built-in default
-- [ ] Omitting `--qr-opts` → `VaContext` uses built-in default
+- [x] `--nosignal-opts` string parsed and forwarded to `VaContext.nosignal_opts`
+- [x] `--qr-opts` string parsed and forwarded to `VaContext.qr_opts`
+- [x] Omitting `--nosignal-opts` → `VaContext` uses built-in default
+- [x] Omitting `--qr-opts` → `VaContext` uses built-in default
+- [ ] `-c / --config` YAML loaded; config values used as defaults, CLI flags override
+- [ ] Config key `nosignal-opts` forwarded to `VaContext.nosignal_opts`
+- [ ] Config key `qr-opts` forwarded to `VaContext.qr_opts`
+- [ ] Config keys for all other CLI options respected
 - [ ] `--mode full` → `VaMode.FULL` passed to `do_main`
 - [ ] Unknown `--mode` value → Click error
 
@@ -137,7 +144,7 @@ Test file location: `tests/qr/test_video_audit.py`
 ## Open Questions / Future Work
 
 - [ ] **Parallel processing** — `--jobs` option for concurrent file processing
-- [ ] **`--nosignal-opts` / `--qr-opts` from config file** — TOML/YAML config support
+- [ ] **`-c / --config` YAML support** — implemented, see CLI Options section
 - [ ] **Progress reporting** — tqdm progress bar for large directories
 - [ ] **`--columns` filter** — select which TSV columns to populate
 - [ ] **DataLad integration** — auto-`datalad save` after TSV update

--- a/.ai/task-video-audit.md
+++ b/.ai/task-video-audit.md
@@ -110,13 +110,105 @@ Test file location: `tests/qr/test_video_audit.py`
 
 ### Unit tests
 
-- [ ] `format_duration` — zero, sub-minute, hours
-- [ ] `format_date` / `format_time` — known datetime → expected string
-- [ ] `check_coherent` — coherent record → `True`; missing fields → `False`
-- [ ] `_compare_rec_ts` — `n/a` ordering, equal timestamps, earlier/later
-- [ ] `_merge_rec` — internal/nosignal/qr timestamp priority
-- [ ] `_merge_recs` — full / force / incremental / rerun-for-na modes
-- [ ] `find_video_audit_by_timerange` — intersects, non-overlapping, boundary cases
+#### Format utilities
+- [ ] `format_duration` — zero, sub-minute, hours, `None` → `"n/a"`
+- [ ] `format_date` — known datetime → `"YYYY-MM-DD"`, `None` → `"n/a"`
+- [ ] `format_time` — known datetime → `"HH:MM:SS.mmm"`, `None` → `"n/a"`
+
+#### `check_coherent`
+- [ ] All fields valid and matching → `True`
+- [ ] `present=False` → `False`
+- [ ] `complete=False` → `False`
+- [ ] Missing start / end date-time → `False`
+- [ ] Missing detected or recorded res/fps → `False`
+- [ ] Resolution mismatch (detected ≠ recorded) → `False`
+- [ ] FPS mismatch (detected ≠ recorded) → `False`
+
+#### `check_ffprobe`
+- [ ] `ffprobe` available (subprocess mock) → `True`
+- [ ] `ffprobe` not found (`FileNotFoundError` mock) → `False`
+
+#### `_compare_rec_ts`
+- [ ] Both `n/a` → `0`
+- [ ] Equal timestamps → `0`
+- [ ] Left `n/a`, right valid → `-1`
+- [ ] Right `n/a`, left valid → `1`
+- [ ] Left earlier → `-1`, left later → `1`
+
+#### `_match_recs`
+- [ ] Identical lists → `True`
+- [ ] Different length → `False`
+- [ ] Same length, different content → `False`
+
+#### `_merge_rec`
+- [ ] All timestamps equal → returns `rec_new`
+- [ ] Newer internal in `rec_new` → internal fields from `rec_new`
+- [ ] Newer nosignal in `rec_cur` → nosignal fields from `rec_cur`
+- [ ] Newer QR in `rec_new` → qr fields from `rec_new`
+
+#### `_merge_recs`
+- [ ] `full` mode → `rec_new` overrides everything
+- [ ] `force` mode → new records merged over existing
+- [ ] `incremental` mode → timestamp-based selective merge
+- [ ] `rerun-for-na` mode → timestamp-based selective merge
+- [ ] No change in `recs_cur` → merge skipped
+
+#### TSV I/O
+- [ ] `_save_tsv` / `_load_tsv` round-trip with temp file
+- [ ] `_get_tsv_records` — with lock (default)
+- [ ] `_get_tsv_records` — cached=True returns cached list on second call
+- [ ] `_get_tsv_records` — use_lock=False dirty-read
+
+#### Metadata log parsing
+- [ ] `iter_metadata_json` — valid JSON lines yielded
+- [ ] `iter_metadata_json` — missing log file → empty generator
+- [ ] `find_metadata_json` — matching entry found
+- [ ] `find_metadata_json` — no matching entry → `None`
+
+#### `_parse_rec_datetime`
+- [ ] Valid date + time strings → `datetime` object
+- [ ] Either value is `"n/a"` → `None`
+
+#### `find_video_audit_by_timerange`
+- [ ] Record intersects range → included in result
+- [ ] Record entirely before range → excluded
+- [ ] Record entirely after range → excluded
+- [ ] Records sorted by start time ascending
+
+#### Path and context helpers
+- [ ] `_build_dated_path` — with valid `start_date` → dated subdirectory created
+- [ ] `_build_dated_path` — `start_date="n/a"` → file placed in base dir
+
+#### `do_audit_file`
+- [ ] Happy path (all mocked): present file, session_begin metadata, full vi/vti/audio → coherent VaRecord yielded
+- [ ] File does not exist → VaRecord with `present=False` yielded
+- [ ] `max_counter` reached → nothing yielded
+- [ ] `skip_names` match → nothing yielded
+- [ ] `path_mask` no-match → nothing yielded
+
+#### `do_audit_dir` / `do_audit_internal`
+- [ ] `do_audit_dir` — directory with .mkv files → records yielded
+- [ ] `do_audit_internal` — skipped for `rerun-for-na` mode
+- [ ] `do_audit_internal` — skipped for `reset-to-na` mode
+
+#### External tool early-exit paths
+- [ ] `run_ext_nosignal` — source not NOSIGNAL/ALL → returns `vr` unchanged
+- [ ] `run_ext_nosignal` — `reset-to-na` mode → `no_signal_frames` set to `"n/a"`
+- [ ] `run_ext_nosignal` — `rerun-for-na` + non-`n/a` → skipped
+- [ ] `run_ext_qr` — source not QR/ALL → returns `vr` unchanged
+- [ ] `run_ext_qr` — `reset-to-na` mode → `qr_records_number` set to `"n/a"`
+- [ ] `run_ext_qr` — `rerun-for-na` + non-`n/a` → skipped
+
+#### `do_main`
+- [ ] Invalid path → returns `1`
+- [ ] Incremental mode, no existing TSV → creates new TSV, returns `0`
+- [ ] Incremental mode, existing TSV → loads existing, merges, saves
+- [ ] `rerun-for-na` mode → calls `do_ext` on existing records
+- [ ] `nosignal_opts` / `qr_opts` strings shlex-parsed into `VaContext`
+
+#### `get_file_video_audit`
+- [ ] TSV exists and contains matching path → returns cached record
+- [ ] TSV missing match → falls back to live `do_audit_file`
 
 ### CLI tests (Click `CliRunner`)
 
@@ -129,6 +221,7 @@ Test file location: `tests/qr/test_video_audit.py`
 - [x] Config key `nosignal-opts` forwarded to `VaContext.nosignal_opts`
 - [x] Config key `qr-opts` forwarded to `VaContext.qr_opts`
 - [x] Config keys for all other CLI options respected
+- [ ] Config `audit-src` as scalar string → wrapped in tuple
 - [ ] `--mode full` → `VaMode.FULL` passed to `do_main`
 - [ ] Unknown `--mode` value → Click error
 
@@ -136,8 +229,8 @@ Test file location: `tests/qr/test_video_audit.py`
 
 | Module | Target | Current |
 |---|---|---|
-| `qr/video_audit.py` — overall | ≥ 80% | 0% (pending) |
-| `cli/cmd_video_audit.py` | ≥ 80% | 0% (pending) |
+| `qr/video_audit.py` — overall | ≥ 80% | 14% |
+| `cli/cmd_video_audit.py` | ≥ 80% | 92% |
 
 ---
 

--- a/.ai/task-video-audit.md
+++ b/.ai/task-video-audit.md
@@ -125,10 +125,10 @@ Test file location: `tests/qr/test_video_audit.py`
 - [x] `--qr-opts` string parsed and forwarded to `VaContext.qr_opts`
 - [x] Omitting `--nosignal-opts` → `VaContext` uses built-in default
 - [x] Omitting `--qr-opts` → `VaContext` uses built-in default
-- [ ] `-c / --config` YAML loaded; config values used as defaults, CLI flags override
-- [ ] Config key `nosignal-opts` forwarded to `VaContext.nosignal_opts`
-- [ ] Config key `qr-opts` forwarded to `VaContext.qr_opts`
-- [ ] Config keys for all other CLI options respected
+- [x] `-c / --config` YAML loaded; config values used as defaults, CLI flags override
+- [x] Config key `nosignal-opts` forwarded to `VaContext.nosignal_opts`
+- [x] Config key `qr-opts` forwarded to `VaContext.qr_opts`
+- [x] Config keys for all other CLI options respected
 - [ ] `--mode full` → `VaMode.FULL` passed to `do_main`
 - [ ] Unknown `--mode` value → Click error
 

--- a/.ai/task-video-audit.md
+++ b/.ai/task-video-audit.md
@@ -111,104 +111,154 @@ Test file location: `tests/qr/test_video_audit.py`
 ### Unit tests
 
 #### Format utilities
-- [ ] `format_duration` — zero, sub-minute, hours, `None` → `"n/a"`
-- [ ] `format_date` — known datetime → `"YYYY-MM-DD"`, `None` → `"n/a"`
-- [ ] `format_time` — known datetime → `"HH:MM:SS.mmm"`, `None` → `"n/a"`
+- [x] `format_duration` — zero, sub-minute, hours, `None` → `"n/a"`
+- [x] `format_date` — known datetime → `"YYYY-MM-DD"`, `None` → `"n/a"`
+- [x] `format_time` — known datetime → `"HH:MM:SS.mmm"`, `None` → `"n/a"`
 
 #### `check_coherent`
-- [ ] All fields valid and matching → `True`
-- [ ] `present=False` → `False`
-- [ ] `complete=False` → `False`
-- [ ] Missing start / end date-time → `False`
-- [ ] Missing detected or recorded res/fps → `False`
-- [ ] Resolution mismatch (detected ≠ recorded) → `False`
-- [ ] FPS mismatch (detected ≠ recorded) → `False`
+- [x] All fields valid and matching → `True`
+- [x] `present=False` → `False`
+- [x] `complete=False` → `False`
+- [x] Missing start / end date-time → `False`
+- [x] Missing detected or recorded res/fps → `False`
+- [x] Resolution mismatch (detected ≠ recorded) → `False`
+- [x] FPS mismatch (detected ≠ recorded) → `False`
 
 #### `check_ffprobe`
-- [ ] `ffprobe` available (subprocess mock) → `True`
-- [ ] `ffprobe` not found (`FileNotFoundError` mock) → `False`
+- [x] `ffprobe` available (subprocess mock) → `True`
+- [x] `ffprobe` not found (`FileNotFoundError` mock) → `False`
+
+#### `get_audio_info_ffprobe`
+- [x] Success with DURATION tag → codec/sample_rate/channels/bits_per_sample/duration set
+- [x] Duration read from stream `duration` field (no DURATION tag)
+- [x] No audio streams → all fields `None`
+- [x] `FileNotFoundError` → returns empty `AudioInfo`
+- [x] `CalledProcessError` → returns empty `AudioInfo`
 
 #### `_compare_rec_ts`
-- [ ] Both `n/a` → `0`
-- [ ] Equal timestamps → `0`
-- [ ] Left `n/a`, right valid → `-1`
-- [ ] Right `n/a`, left valid → `1`
-- [ ] Left earlier → `-1`, left later → `1`
+- [x] Both `n/a` → `0`
+- [x] Equal timestamps → `0`
+- [x] Left `n/a`, right valid → `-1`
+- [x] Right `n/a`, left valid → `1`
+- [x] Left earlier → `-1`, left later → `1`
 
 #### `_match_recs`
-- [ ] Identical lists → `True`
-- [ ] Different length → `False`
-- [ ] Same length, different content → `False`
+- [x] Identical lists → `True`
+- [x] Different length → `False`
+- [x] Same length, different content → `False`
 
 #### `_merge_rec`
-- [ ] All timestamps equal → returns `rec_new`
-- [ ] Newer internal in `rec_new` → internal fields from `rec_new`
-- [ ] Newer nosignal in `rec_cur` → nosignal fields from `rec_cur`
-- [ ] Newer QR in `rec_new` → qr fields from `rec_new`
+- [x] All timestamps equal → returns `rec_new`
+- [x] Newer internal in `rec_new` → internal fields from `rec_new`
+- [x] Newer nosignal in `rec_cur` → nosignal fields from `rec_cur`
+- [x] Newer QR in `rec_new` → qr fields from `rec_new`
+- [x] Name mismatch → `ValueError` raised
 
 #### `_merge_recs`
-- [ ] `full` mode → `rec_new` overrides everything
-- [ ] `force` mode → new records merged over existing
-- [ ] `incremental` mode → timestamp-based selective merge
-- [ ] `rerun-for-na` mode → timestamp-based selective merge
-- [ ] No change in `recs_cur` → merge skipped
+- [x] `full` mode → `rec_new` overrides everything
+- [x] `force` mode → new records merged over existing
+- [x] `force` mode with empty `recs_cur` → returns `recs_new` directly
+- [x] `incremental` mode → timestamp-based selective merge
+- [x] `incremental` mode → brand-new record added alongside existing
+- [x] `rerun-for-na` mode → timestamp-based selective merge
+- [x] No change in `recs_cur` → merge skipped
 
 #### TSV I/O
-- [ ] `_save_tsv` / `_load_tsv` round-trip with temp file
-- [ ] `_get_tsv_records` — with lock (default)
-- [ ] `_get_tsv_records` — cached=True returns cached list on second call
-- [ ] `_get_tsv_records` — use_lock=False dirty-read
+- [x] `_save_tsv` / `_load_tsv` round-trip with temp file
+- [x] `_get_tsv_records` — with lock (default)
+- [x] `_get_tsv_records` — cached=True returns cached list on second call
+- [x] `_get_tsv_records` — use_lock=False dirty-read
 
 #### Metadata log parsing
-- [ ] `iter_metadata_json` — valid JSON lines yielded
-- [ ] `iter_metadata_json` — missing log file → empty generator
-- [ ] `find_metadata_json` — matching entry found
-- [ ] `find_metadata_json` — no matching entry → `None`
+- [x] `iter_metadata_json` — valid JSON lines yielded
+- [x] `iter_metadata_json` — missing log file → empty generator
+- [x] `iter_metadata_json` — invalid JSON in line → silently skipped
+- [x] `find_metadata_json` — matching entry found
+- [x] `find_metadata_json` — no matching entry → `None`
 
 #### `_parse_rec_datetime`
-- [ ] Valid date + time strings → `datetime` object
-- [ ] Either value is `"n/a"` → `None`
+- [x] Valid date + time strings → `datetime` object
+- [x] Either value is `"n/a"` → `None`
+- [x] Malformed strings → `None` (ValueError path)
 
 #### `find_video_audit_by_timerange`
-- [ ] Record intersects range → included in result
-- [ ] Record entirely before range → excluded
-- [ ] Record entirely after range → excluded
-- [ ] Records sorted by start time ascending
+- [x] Record intersects range → included in result
+- [x] Record entirely before range → excluded
+- [x] Record entirely after range → excluded
+- [x] Records sorted by start time ascending
+- [x] `present=False` → excluded
+- [x] `complete=False` → excluded
+- [x] `start_date="n/a"` → excluded
+- [x] `end_date="n/a"` → excluded
 
 #### Path and context helpers
-- [ ] `_build_dated_path` — with valid `start_date` → dated subdirectory created
-- [ ] `_build_dated_path` — `start_date="n/a"` → file placed in base dir
+- [x] `_build_dated_path` — with valid `start_date` → dated subdirectory created
+- [x] `_build_dated_path` — `start_date="n/a"` → file placed in base dir
 
 #### `do_audit_file`
-- [ ] Happy path (all mocked): present file, session_begin metadata, full vi/vti/audio → coherent VaRecord yielded
-- [ ] File does not exist → VaRecord with `present=False` yielded
-- [ ] `max_counter` reached → nothing yielded
-- [ ] `skip_names` match → nothing yielded
-- [ ] `path_mask` no-match → nothing yielded
+- [x] Happy path (all mocked): present file, session_begin metadata, full vi/vti/audio → coherent VaRecord yielded
+- [x] File does not exist → VaRecord with `present=False` yielded
+- [x] `max_counter` reached → nothing yielded
+- [x] `skip_names` match by full path → nothing yielded
+- [x] `skip_names` match by base name (after existence check) → nothing yielded
+- [x] `path_mask` no-match → nothing yielded
 
 #### `do_audit_dir` / `do_audit_internal`
-- [ ] `do_audit_dir` — directory with .mkv files → records yielded
-- [ ] `do_audit_internal` — skipped for `rerun-for-na` mode
-- [ ] `do_audit_internal` — skipped for `reset-to-na` mode
+- [x] `do_audit_dir` — directory with .mkv files → records yielded
+- [x] `do_audit_dir` — missing path → nothing yielded
+- [x] `do_audit_dir` — non-directory path → nothing yielded
+- [x] `do_audit_dir` — `max_counter` reached → nothing yielded
+- [x] `do_audit_dir` — recursive descent into subdirectory
+- [x] `do_audit_internal` — skipped for `rerun-for-na` mode
+- [x] `do_audit_internal` — skipped for `reset-to-na` mode
+- [x] `do_audit_internal` — skipped for non-INTERNAL source
+- [x] `do_audit_internal` — single file path → delegates to `do_audit_file`
+- [x] `do_audit_internal` — directory path → delegates to `do_audit_dir`
+- [x] `do_audit_internal` — non-existent path → nothing yielded
 
 #### External tool early-exit paths
-- [ ] `run_ext_nosignal` — source not NOSIGNAL/ALL → returns `vr` unchanged
-- [ ] `run_ext_nosignal` — `reset-to-na` mode → `no_signal_frames` set to `"n/a"`
-- [ ] `run_ext_nosignal` — `rerun-for-na` + non-`n/a` → skipped
-- [ ] `run_ext_qr` — source not QR/ALL → returns `vr` unchanged
-- [ ] `run_ext_qr` — `reset-to-na` mode → `qr_records_number` set to `"n/a"`
-- [ ] `run_ext_qr` — `rerun-for-na` + non-`n/a` → skipped
+- [x] `run_ext_nosignal` — source not NOSIGNAL/ALL → returns `vr` unchanged
+- [x] `run_ext_nosignal` — `reset-to-na` mode → `no_signal_frames` set to `"n/a"`
+- [x] `run_ext_nosignal` — `reset-to-na` already `n/a` → counter not incremented
+- [x] `run_ext_nosignal` — `rerun-for-na` + non-`n/a` → skipped
+- [x] `run_ext_nosignal` — `max_counter` reached → returns `vr` unchanged
+- [x] `run_ext_nosignal` — `path_mask` no-match → returns `vr` unchanged
+- [x] `run_ext_nosignal` — subprocess success with `nosignal_rate` → percentage stored
+- [x] `run_ext_nosignal` — subprocess success without `nosignal_rate` key → `"0.0"`
+- [x] `run_ext_nosignal` — `CalledProcessError` → `no_signal_frames` unchanged
+- [x] `run_ext_qr` — source not QR/ALL → returns `vr` unchanged
+- [x] `run_ext_qr` — `reset-to-na` mode → `qr_records_number` set to `"n/a"`
+- [x] `run_ext_qr` — `reset-to-na` already `n/a` → counter not incremented
+- [x] `run_ext_qr` — `rerun-for-na` + non-`n/a` → skipped
+- [x] `run_ext_qr` — `max_counter` reached → returns `vr` unchanged
+- [x] `run_ext_qr` — `path_mask` no-match → returns `vr` unchanged
+- [x] `run_ext_qr` — subprocess success with `ParseSummary` → `qr_count` stored
+- [x] `run_ext_qr` — ffmpeg `CalledProcessError` → `qr_records_number` = `"-2"`
+- [x] `run_ext_qr` — no `ParseSummary` in output → `qr_records_number` = `"-1"`
+- [x] `run_ext_all` — delegates to nosignal then qr
+- [x] `do_audit` — delegates to `do_audit_internal` + `run_ext_all`
+
+#### `do_ext`
+- [x] Empty path list → all records processed
+- [x] `["*"]` path list → all records processed
+- [x] Record path matches explicit file → processed
+- [x] Record path starts with directory → processed
+- [x] Record not matching filter → yielded unchanged
 
 #### `do_main`
-- [ ] Invalid path → returns `1`
-- [ ] Incremental mode, no existing TSV → creates new TSV, returns `0`
-- [ ] Incremental mode, existing TSV → loads existing, merges, saves
-- [ ] `rerun-for-na` mode → calls `do_ext` on existing records
-- [ ] `nosignal_opts` / `qr_opts` strings shlex-parsed into `VaContext`
+- [x] Invalid path → returns `1`
+- [x] Incremental mode, no existing TSV → creates new TSV, returns `0`
+- [x] Incremental mode, existing TSV → loads existing, merges, saves
+- [x] `rerun-for-na` mode → calls `do_ext` on existing records
+- [x] `nosignal_opts` / `qr_opts` strings shlex-parsed into `VaContext`
+- [x] `ffprobe` missing → prints error message, still returns `0`
+- [x] `verbose=True` → records printed as JSON via `out_func`
 
 #### `get_file_video_audit`
-- [ ] TSV exists and contains matching path → returns cached record
-- [ ] TSV missing match → falls back to live `do_audit_file`
+- [x] TSV exists and contains matching path → returns cached record
+- [x] TSV missing match → falls back to live `do_audit_file`
+- [x] `Timeout` while acquiring lock → falls back to `do_audit_file`
+- [x] Generic exception loading TSV → falls back to `do_audit_file`
 
 ### CLI tests (Click `CliRunner`)
 
@@ -221,16 +271,16 @@ Test file location: `tests/qr/test_video_audit.py`
 - [x] Config key `nosignal-opts` forwarded to `VaContext.nosignal_opts`
 - [x] Config key `qr-opts` forwarded to `VaContext.qr_opts`
 - [x] Config keys for all other CLI options respected
-- [ ] Config `audit-src` as scalar string → wrapped in tuple
-- [ ] `--mode full` → `VaMode.FULL` passed to `do_main`
-- [ ] Unknown `--mode` value → Click error
+- [x] Config `audit-src` as scalar string → wrapped in tuple
+- [x] `--mode full` → `VaMode.FULL` passed to `do_main`
+- [x] Unknown `--mode` value → Click error
 
 ### Coverage targets
 
 | Module | Target | Current |
 |---|---|---|
-| `qr/video_audit.py` — overall | ≥ 80% | 14% |
-| `cli/cmd_video_audit.py` | ≥ 80% | 92% |
+| `qr/video_audit.py` — overall | ≥ 80% | 93% |
+| `cli/cmd_video_audit.py` | ≥ 80% | 94% |
 
 ---
 

--- a/.ai/task-video-audit.md
+++ b/.ai/task-video-audit.md
@@ -120,7 +120,7 @@ Test file location: `tests/qr/test_video_audit.py`
 
 ### CLI tests (Click `CliRunner`)
 
-- [ ] `--help` renders without error
+- [x] `--help` renders without error
 - [x] `--nosignal-opts` string parsed and forwarded to `VaContext.nosignal_opts`
 - [x] `--qr-opts` string parsed and forwarded to `VaContext.qr_opts`
 - [x] Omitting `--nosignal-opts` → `VaContext` uses built-in default

--- a/.ai/task-video-audit.md
+++ b/.ai/task-video-audit.md
@@ -14,8 +14,8 @@ Tracks implementation progress against [spec-video-audit.md](spec-video-audit.md
 - [x] `-l / --max-files` — limit number of records processed
 - [x] `-p / --path-mask` — fnmatch-style filter on file paths
 - [x] `-v / --verbose` — print JSON records to stdout
-- [x] `--nosignal-opts` — override detect-noscreen options (shlex string)
-- [x] `--qr-opts` — override qr-parse options (shlex string)
+- [ ] `--nosignal-opts` — override detect-noscreen options (shlex string)
+- [ ] `--qr-opts` — override qr-parse options (shlex string)
 
 ---
 
@@ -43,8 +43,8 @@ Tracks implementation progress against [spec-video-audit.md](spec-video-audit.md
 - [x] Store log output under dated path in `nosignal_log_dir`
 - [x] Parse `nosignal_rate` from JSON and store as percentage
 - [x] Per-file lock (`.nosignal.lock`) to prevent concurrent runs
-- [x] Pass `nosignal_opts` to detect-noscreen via `VaContext`
-- [x] Accept `--nosignal-opts` override from CLI (shlex-parsed)
+- [ ] Pass `nosignal_opts` to detect-noscreen via `VaContext`
+- [ ] Accept `--nosignal-opts` override from CLI (shlex-parsed)
 
 ### External audit — QR (`VaSource.QR`)
 - [x] Convert video to audio-free copy via ffmpeg (temp dir)
@@ -53,8 +53,8 @@ Tracks implementation progress against [spec-video-audit.md](spec-video-audit.md
 - [x] Store log output under dated path in `qr_log_dir`
 - [x] Parse `ParseSummary.qr_count` from JSONL output
 - [x] Per-file lock (`.qr.lock`) to prevent concurrent runs
-- [x] Pass `qr_opts` to qr-parse via `VaContext`
-- [x] Accept `--qr-opts` override from CLI (shlex-parsed)
+- [ ] Pass `qr_opts` to qr-parse via `VaContext`
+- [ ] Accept `--qr-opts` override from CLI (shlex-parsed)
 
 ### Operation modes (`VaMode`)
 - [x] `full` — regenerate all records from scratch

--- a/.ai/task-video-audit.md
+++ b/.ai/task-video-audit.md
@@ -1,0 +1,143 @@
+# `video-audit` Task List
+
+Tracks implementation progress against [spec-video-audit.md](spec-video-audit.md).
+
+---
+
+## CLI Options
+
+- [x] `PATHS` argument — one or more video files or directories
+- [x] `-m / --mode [full|incremental|force|rerun-for-na|reset-to-na]`
+- [x] `-o / --output` — output TSV file (default: `videos.tsv`)
+- [x] `-r / --recursive` — recursively scan subdirectories
+- [x] `-s / --audit-src [internal|qr|nosignal|all]` — repeatable
+- [x] `-l / --max-files` — limit number of records processed
+- [x] `-p / --path-mask` — fnmatch-style filter on file paths
+- [x] `-v / --verbose` — print JSON records to stdout
+- [x] `--nosignal-opts` — override detect-noscreen options (shlex string)
+- [x] `--qr-opts` — override qr-parse options (shlex string)
+
+---
+
+## Core Logic
+
+### File discovery
+- [x] Process a single video file directly
+- [x] Scan a directory for `.mkv`, `.mp4`, `.avi` files
+- [x] Recursive directory traversal (`--recursive`)
+- [x] Mixed list of files and directories in a single invocation
+- [x] fnmatch path mask filtering (`--path-mask`)
+- [x] `skip_names` set to skip already-processed files in incremental mode
+
+### Internal audit (`VaSource.INTERNAL`)
+- [x] Extract start/end timestamps from `.log` sidecar
+- [x] Extract video resolution and FPS from `session_begin` metadata
+- [x] Extract recorded resolution/FPS/duration via `qr_parse.do_info_file`
+- [x] Extract audio info (codec, sample rate, channels, duration) via ffprobe
+- [x] Compute human-readable duration (`HH:MM:SS.mmm`)
+- [x] Coherence check (`check_coherent`) — res/fps/timestamps consistent
+
+### External audit — nosignal (`VaSource.NOSIGNAL`)
+- [x] Run `reprostim detect-noscreen` on each video
+- [x] Store JSON output under dated path in `nosignal_data_dir`
+- [x] Store log output under dated path in `nosignal_log_dir`
+- [x] Parse `nosignal_rate` from JSON and store as percentage
+- [x] Per-file lock (`.nosignal.lock`) to prevent concurrent runs
+- [x] Pass `nosignal_opts` to detect-noscreen via `VaContext`
+- [x] Accept `--nosignal-opts` override from CLI (shlex-parsed)
+
+### External audit — QR (`VaSource.QR`)
+- [x] Convert video to audio-free copy via ffmpeg (temp dir)
+- [x] Run `reprostim qr-parse` on temp copy
+- [x] Store JSONL output under dated path in `qr_data_dir`
+- [x] Store log output under dated path in `qr_log_dir`
+- [x] Parse `ParseSummary.qr_count` from JSONL output
+- [x] Per-file lock (`.qr.lock`) to prevent concurrent runs
+- [x] Pass `qr_opts` to qr-parse via `VaContext`
+- [x] Accept `--qr-opts` override from CLI (shlex-parsed)
+
+### Operation modes (`VaMode`)
+- [x] `full` — regenerate all records from scratch
+- [x] `incremental` — process only new files, merge into existing TSV
+- [x] `force` — redo/update existing records
+- [x] `rerun-for-na` — rerun external tools only for records with `n/a` values
+- [x] `reset-to-na` — reset external-tool fields to `n/a`
+
+### TSV handling
+- [x] Load existing `videos.tsv` with file lock
+- [x] Save sorted records to `videos.tsv`
+- [x] `_merge_recs` — timestamp-aware merge of old/current/new record sets
+- [x] `_merge_rec` — per-record merge using `updated_on`, `no_signal_updated_on`, `qr_updated_on`
+- [x] Module-level TSV cache (`_tsv_cache`) with `cached` / `use_lock` flags
+- [x] `find_video_audit_by_timerange` — intersect-based lookup for BIDS injection
+
+---
+
+## API
+
+- [x] `VaRecord` — Pydantic model for a single TSV row
+- [x] `VaContext` — Pydantic model carrying all processing options
+- [x] `VaMode` — enum of operation modes
+- [x] `VaSource` — enum of audit sources
+- [x] `do_audit_file` — audit a single video file (INTERNAL)
+- [x] `do_audit_dir` — audit all videos in a directory
+- [x] `do_audit_internal` — entry point for INTERNAL source
+- [x] `run_ext_nosignal` — run detect-noscreen on a record
+- [x] `run_ext_qr` — run qr-parse on a record
+- [x] `run_ext_all` — run all external tools on a record
+- [x] `do_audit` — full pipeline (internal + external)
+- [x] `do_ext` — external-only pass over existing records
+- [x] `do_main` — CLI entry point
+- [x] `get_file_video_audit` — single-file lookup (TSV or live audit)
+- [x] `find_video_audit_by_timerange` — time-range lookup for BIDS
+
+---
+
+## Documentation
+
+- [x] `video-audit` listed in RTD CLI index
+- [ ] `video-audit` RST reference page with full option descriptions
+- [ ] `VaContext` / `VaRecord` added to RTD API reference
+
+---
+
+## Tests and Code Coverage
+
+Test file location: `tests/qr/test_video_audit.py`
+
+### Unit tests
+
+- [ ] `format_duration` — zero, sub-minute, hours
+- [ ] `format_date` / `format_time` — known datetime → expected string
+- [ ] `check_coherent` — coherent record → `True`; missing fields → `False`
+- [ ] `_compare_rec_ts` — `n/a` ordering, equal timestamps, earlier/later
+- [ ] `_merge_rec` — internal/nosignal/qr timestamp priority
+- [ ] `_merge_recs` — full / force / incremental / rerun-for-na modes
+- [ ] `find_video_audit_by_timerange` — intersects, non-overlapping, boundary cases
+
+### CLI tests (Click `CliRunner`)
+
+- [ ] `--help` renders without error
+- [ ] `--nosignal-opts` string parsed and forwarded to `VaContext.nosignal_opts`
+- [ ] `--qr-opts` string parsed and forwarded to `VaContext.qr_opts`
+- [ ] Omitting `--nosignal-opts` → `VaContext` uses built-in default
+- [ ] Omitting `--qr-opts` → `VaContext` uses built-in default
+- [ ] `--mode full` → `VaMode.FULL` passed to `do_main`
+- [ ] Unknown `--mode` value → Click error
+
+### Coverage targets
+
+| Module | Target | Current |
+|---|---|---|
+| `qr/video_audit.py` — overall | ≥ 80% | 0% (pending) |
+| `cli/cmd_video_audit.py` | ≥ 80% | 0% (pending) |
+
+---
+
+## Open Questions / Future Work
+
+- [ ] **Parallel processing** — `--jobs` option for concurrent file processing
+- [ ] **`--nosignal-opts` / `--qr-opts` from config file** — TOML/YAML config support
+- [ ] **Progress reporting** — tqdm progress bar for large directories
+- [ ] **`--columns` filter** — select which TSV columns to populate
+- [ ] **DataLad integration** — auto-`datalad save` after TSV update

--- a/.ai/task-video-audit.md
+++ b/.ai/task-video-audit.md
@@ -17,8 +17,8 @@ Tracks implementation progress against [spec-video-audit.md](spec-video-audit.md
 - [x] `-n / --nosignal-opts` — override detect-noscreen options (shlex string)
 - [x] `-q / --qr-opts` — override qr-parse options (shlex string)
 - [x] Add short forms `-n` and `-q` to existing `--nosignal-opts` / `--qr-opts` in CLI code
-- [ ] `-c / --config` — optional YAML config file with CLI-override precedence
-- [ ] Add `pyyaml>=6.0` to `pyproject.toml` dependencies
+- [x] `-c / --config` — optional YAML config file with CLI-override precedence
+- [x] Add `pyyaml>=6.0` to `pyproject.toml` dependencies
 
 ---
 
@@ -144,7 +144,7 @@ Test file location: `tests/qr/test_video_audit.py`
 ## Open Questions / Future Work
 
 - [ ] **Parallel processing** — `--jobs` option for concurrent file processing
-- [ ] **`-c / --config` YAML support** — implemented, see CLI Options section
+- [x] **`-c / --config` YAML support** — implemented
 - [ ] **Progress reporting** — tqdm progress bar for large directories
 - [ ] **`--columns` filter** — select which TSV columns to populate
 - [ ] **DataLad integration** — auto-`datalad save` after TSV update

--- a/.ai/task-video-audit.md
+++ b/.ai/task-video-audit.md
@@ -16,7 +16,7 @@ Tracks implementation progress against [spec-video-audit.md](spec-video-audit.md
 - [x] `-v / --verbose` — print JSON records to stdout
 - [x] `-n / --nosignal-opts` — override detect-noscreen options (shlex string)
 - [x] `-q / --qr-opts` — override qr-parse options (shlex string)
-- [ ] Add short forms `-n` and `-q` to existing `--nosignal-opts` / `--qr-opts` in CLI code
+- [x] Add short forms `-n` and `-q` to existing `--nosignal-opts` / `--qr-opts` in CLI code
 - [ ] `-c / --config` — optional YAML config file with CLI-override precedence
 - [ ] Add `pyyaml>=6.0` to `pyproject.toml` dependencies
 

--- a/examples/video-audit/config.yaml
+++ b/examples/video-audit/config.yaml
@@ -1,0 +1,39 @@
+# video-audit config example
+# Usage: reprostim video-audit -c config.yaml [PATHS]...
+#
+# CLI flags always take precedence over values defined here.
+# Uncomment and adjust any key to override the built-in CLI default.
+
+# Operation mode: incremental | full | force | rerun-for-na | reset-to-na
+#mode: incremental
+
+# Output TSV file
+#output: videos.tsv
+
+# Recursively scan subdirectories
+#recursive: false
+
+# Audit sources to run.
+# Use a list to combine sources (equivalent to: -s internal -s qr).
+# Allowed values: internal | qr | nosignal | all
+#audit-src:
+#  - internal
+#  - qr
+#  - nosignal
+#  - all
+
+# Maximum number of video files/records to process (-1 = unlimited)
+#max-files: -1
+
+# fnmatch-style filter on file paths, e.g. "*/2025/*/*.mkv"
+#path-mask: "*/2025/*/*.mkv"
+
+# Print each record as JSON to stdout
+#verbose: false
+
+# Options forwarded to reprostim detect-noscreen (shlex-parsed string).
+# Overrides the built-in defaults when set.
+#nosignal-opts: "--number-of-checks 200 --threshold 0.9 --truncated fixup --invalid-timing fixup"
+
+# Extra options forwarded to reprostim qr-parse (shlex-parsed string).
+#qr-opts: "--skip 2 --std-threshold 15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "opencv-python>=4.9.0.80",
   "filelock>=3.16.0",
   "isodate>=0.7.2",
+  "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/reprostim/cli/cmd_video_audit.py
+++ b/src/reprostim/cli/cmd_video_audit.py
@@ -6,9 +6,24 @@ import logging
 import os
 
 import click
+import yaml
+from click.core import ParameterSource
 
 # setup logging
 logger = logging.getLogger(__name__)
+
+
+def _load_config(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _apply_config(ctx, config: dict, param_name: str, current_val):
+    """Return the config value when the param was not explicitly set on CLI."""
+    if ctx.get_parameter_source(param_name) != ParameterSource.DEFAULT:
+        return current_val
+    key = param_name.replace("_", "-")
+    return config.get(key, current_val)
 
 
 @click.command(
@@ -136,6 +151,17 @@ logger = logging.getLogger(__name__)
         "If omitted, no extra options are passed."
     ),
 )
+@click.option(
+    "-c",
+    "--config",
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False, file_okay=True),
+    default=None,
+    help=(
+        "Optional YAML config file providing defaults for any option not "
+        "explicitly set on the CLI. CLI flags always take precedence."
+    ),
+)
 @click.pass_context
 def video_audit(
     ctx,
@@ -149,13 +175,32 @@ def video_audit(
     verbose: bool,
     nosignal_opts: str,
     qr_opts: str,
+    config_path: str,
 ):
     """Analyze recorded video files."""
 
     from ..qr.video_audit import VaMode, VaSource, do_main
 
+    # load config file and apply as defaults for any param not set on CLI
+    config = _load_config(config_path) if config_path else {}
+    mode = _apply_config(ctx, config, "mode", mode)
+    output = _apply_config(ctx, config, "output", output)
+    recursive = _apply_config(ctx, config, "recursive", recursive)
+    audit_src = _apply_config(ctx, config, "audit_src", audit_src)
+    if isinstance(audit_src, str):
+        audit_src = (audit_src,)
+    elif isinstance(audit_src, list):
+        audit_src = tuple(audit_src)
+    max_files = _apply_config(ctx, config, "max_files", max_files)
+    path_mask = _apply_config(ctx, config, "path_mask", path_mask)
+    verbose = _apply_config(ctx, config, "verbose", verbose)
+    nosignal_opts = _apply_config(ctx, config, "nosignal_opts", nosignal_opts)
+    qr_opts = _apply_config(ctx, config, "qr_opts", qr_opts)
+
     logger.debug("video_audit(...)")
     logger.debug(f"Working dir      : {os.getcwd()}")
+    if config_path:
+        logger.info(f"Config file      : {config_path}")
     logger.info(f"Video full paths : {paths}")
     logger.info(f"Output TSV file  : {output}")
     logger.info(f"Recursive scan   : {recursive}")

--- a/src/reprostim/cli/cmd_video_audit.py
+++ b/src/reprostim/cli/cmd_video_audit.py
@@ -113,6 +113,27 @@ logger = logging.getLogger(__name__)
     default=False,
     help="Enable verbose output with JSON records.",
 )
+@click.option(
+    "--nosignal-opts",
+    type=str,
+    default=None,
+    help=(
+        "Override default options passed to detect-noscreen tool. "
+        "Provide as a quoted string, e.g. "
+        "'--number-of-checks 200 --threshold 0.9'. "
+        "If omitted, built-in defaults are used."
+    ),
+)
+@click.option(
+    "--qr-opts",
+    type=str,
+    default=None,
+    help=(
+        "Additional options to pass to qr-parse tool. "
+        "Provide as a quoted string, e.g. '--some-flag value'. "
+        "If omitted, no extra options are passed."
+    ),
+)
 @click.pass_context
 def video_audit(
     ctx,
@@ -124,6 +145,8 @@ def video_audit(
     max_files: int,
     path_mask: str,
     verbose: bool,
+    nosignal_opts: str,
+    qr_opts: str,
 ):
     """Analyze recorded video files."""
 
@@ -140,6 +163,10 @@ def video_audit(
     if path_mask:
         logger.info(f"Path mask        : {path_mask}")
     logger.info(f"Verbose output   : {verbose}")
+    if nosignal_opts:
+        logger.info(f"Nosignal opts    : {nosignal_opts}")
+    if qr_opts:
+        logger.info(f"QR opts          : {qr_opts}")
 
     for path in paths:
         if not os.path.exists(path):
@@ -156,5 +183,7 @@ def video_audit(
         path_mask,
         verbose,
         click.echo,
+        nosignal_opts=nosignal_opts,
+        qr_opts=qr_opts,
     )
     return 0

--- a/src/reprostim/cli/cmd_video_audit.py
+++ b/src/reprostim/cli/cmd_video_audit.py
@@ -114,6 +114,7 @@ logger = logging.getLogger(__name__)
     help="Enable verbose output with JSON records.",
 )
 @click.option(
+    "-n",
     "--nosignal-opts",
     type=str,
     default=None,
@@ -125,6 +126,7 @@ logger = logging.getLogger(__name__)
     ),
 )
 @click.option(
+    "-q",
     "--qr-opts",
     type=str,
     default=None,

--- a/src/reprostim/qr/video_audit.py
+++ b/src/reprostim/qr/video_audit.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import subprocess
 import tempfile
 import traceback
@@ -1452,6 +1453,8 @@ def do_main(
     path_mask: str = None,
     verbose: bool = False,
     out_func=print,
+    nosignal_opts: str = None,
+    qr_opts: str = None,
 ):
     """The main function invoked by CLI to analyze video files with
     logs and save the results to a TSV file.
@@ -1485,6 +1488,15 @@ def do_main(
 
     :param out_func: Function to stdout results (default: print)
     :type out_func: Callable[[str], None]
+
+    :param nosignal_opts: Optional string of extra options to pass to
+                          detect-noscreen, parsed via shlex. Overrides
+                          the built-in defaults when provided.
+    :type nosignal_opts: str
+
+    :param qr_opts: Optional string of extra options to pass to qr-parse,
+                    parsed via shlex. No extra options by default.
+    :type qr_opts: str
 
     :return: 0 on success, 1 on failure
     :rtype: int
@@ -1538,7 +1550,17 @@ def do_main(
         log_level=os.environ["REPROSTIM_LOG_LEVEL"],
         max_counter=max_files,
         mode=mode,
+        nosignal_opts=(
+            shlex.split(nosignal_opts)
+            if nosignal_opts is not None
+            else VaContext.model_fields["nosignal_opts"].default
+        ),
         path_mask=path_mask,
+        qr_opts=(
+            shlex.split(qr_opts)
+            if qr_opts is not None
+            else VaContext.model_fields["qr_opts"].default
+        ),
         recursive=recursive,
         source=va_src,
     )

--- a/src/reprostim/qr/video_audit.py
+++ b/src/reprostim/qr/video_audit.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel
 
 from reprostim.qr.qr_parse import (
     InfoSummary,
+    ParseContext,
     ParseSummary,
     VideoTimeInfo,
     do_info_file,
@@ -766,7 +767,8 @@ def do_audit_file(ctx: VaContext, path: str) -> Generator[VaRecord, None, None]:
                 if vi.rate_mbpm is not None:
                     vr.video_rate_mbpm = str(vi.rate_mbpm)
 
-                ps: ParseSummary = next(do_parse(path, True, True))
+                # Note: just quick parse w/o QR processing so default context is used
+                ps: ParseSummary = next(do_parse(ParseContext(), path, True, True))
                 logger.info(f"ps: {ps}")
                 if ps is not None:
                     if (

--- a/tests/qr/test_video_audit.py
+++ b/tests/qr/test_video_audit.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2020-2026 ReproNim Team <info@repronim.org>
+#
+# SPDX-License-Identifier: MIT
+
+"""CLI tests for ``reprostim video-audit``.
+
+Covers: --nosignal-opts, --qr-opts and their default behaviour.
+``do_main`` is patched so no real video processing takes place.
+"""
+
+from unittest.mock import patch
+
+import click.testing
+import pytest
+
+from reprostim.cli.cmd_video_audit import video_audit
+
+runner = click.testing.CliRunner()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_mkv(tmp_path):
+    """Return a path to an empty .mkv file accepted by click.Path(exists=True)."""
+    p = tmp_path / "test.mkv"
+    p.touch()
+    return str(p)
+
+
+def _invoke(args):
+    """Invoke the video_audit command and return the result."""
+    return runner.invoke(video_audit, args, catch_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# --help
+# ---------------------------------------------------------------------------
+
+
+def test_help_renders():
+    """--help exits cleanly and lists all key options."""
+    result = runner.invoke(video_audit, ["--help"])
+    assert result.exit_code == 0
+    for flag in ("--nosignal-opts", "--qr-opts", "--config", "--mode", "--audit-src"):
+        assert flag in result.output
+
+
+# ---------------------------------------------------------------------------
+# --nosignal-opts / -n
+# ---------------------------------------------------------------------------
+
+
+def test_nosignal_opts_forwarded(tmp_mkv):
+    """-n / --nosignal-opts value is forwarded to do_main as nosignal_opts kwarg."""
+    opts = "--number-of-checks 200 --threshold 0.9"
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["-n", opts, tmp_mkv])
+    assert result.exit_code == 0
+    assert mock_do_main.call_args.kwargs["nosignal_opts"] == opts
+
+
+def test_nosignal_opts_short_form_forwarded(tmp_mkv):
+    """Short form -n is accepted and forwards the value identically
+    to --nosignal-opts."""
+    opts = "--number-of-checks 50"
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["--nosignal-opts", opts, tmp_mkv])
+    assert result.exit_code == 0
+    assert mock_do_main.call_args.kwargs["nosignal_opts"] == opts
+
+
+def test_nosignal_opts_default_is_none(tmp_mkv):
+    """Omitting --nosignal-opts passes nosignal_opts=None so VaContext uses
+    built-in defaults."""
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke([tmp_mkv])
+    assert result.exit_code == 0
+    assert mock_do_main.call_args.kwargs["nosignal_opts"] is None
+
+
+# ---------------------------------------------------------------------------
+# --qr-opts / -q
+# ---------------------------------------------------------------------------
+
+
+def test_qr_opts_forwarded(tmp_mkv):
+    """-q / --qr-opts value is forwarded to do_main as qr_opts kwarg."""
+    opts = "--skip 2 --std-threshold 15"
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["-q", opts, tmp_mkv])
+    assert result.exit_code == 0
+    assert mock_do_main.call_args.kwargs["qr_opts"] == opts
+
+
+def test_qr_opts_short_form_forwarded(tmp_mkv):
+    """Short form -q is accepted and forwards the value identically to --qr-opts."""
+    opts = "--skip 4"
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["--qr-opts", opts, tmp_mkv])
+    assert result.exit_code == 0
+    assert mock_do_main.call_args.kwargs["qr_opts"] == opts
+
+
+def test_qr_opts_default_is_none(tmp_mkv):
+    """Omitting --qr-opts passes qr_opts=None so no extra options are forwarded."""
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke([tmp_mkv])
+    assert result.exit_code == 0
+    assert mock_do_main.call_args.kwargs["qr_opts"] is None

--- a/tests/qr/test_video_audit.py
+++ b/tests/qr/test_video_audit.py
@@ -10,8 +10,6 @@ Covers: --nosignal-opts, --qr-opts, --config and their default behaviour.
 
 import json
 import os
-
-# import subprocess
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -1017,3 +1015,705 @@ def test_get_file_video_audit_tsv_miss_fallback(tmp_path):
     ):
         result = get_file_video_audit(str(mkv), path_tsv=tsv, use_lock=False)
     assert result is not None and result.name == "test.mkv"
+
+
+# ===========================================================================
+# iter_metadata_json — invalid JSON branch
+# ===========================================================================
+
+
+def test_iter_metadata_json_invalid_json(tmp_path):
+    """Invalid JSON embedded in a metadata marker line is silently skipped."""
+    log = tmp_path / "bad.log"
+    log.write_text(
+        "PREFIX REPROSTIM-METADATA-JSON: not-valid-json :REPROSTIM-METADATA-JSON\n"
+    )
+    assert list(iter_metadata_json(str(log))) == []
+
+
+# ===========================================================================
+# get_audio_info_ffprobe
+# ===========================================================================
+
+
+def test_get_audio_info_ffprobe_success():
+
+    from reprostim.qr.video_audit import get_audio_info_ffprobe
+
+    ffprobe_output = json.dumps(
+        {
+            "streams": [
+                {
+                    "codec_type": "audio",
+                    "codec_name": "pcm_s16le",
+                    "sample_rate": "44100",
+                    "channels": 2,
+                    "bits_per_sample": 16,
+                    "tags": {"DURATION": "00:01:00.000000000"},
+                }
+            ]
+        }
+    )
+    mock_result = MagicMock(stdout=ffprobe_output, returncode=0)
+    with patch("reprostim.qr.video_audit.subprocess.run", return_value=mock_result):
+        ai = get_audio_info_ffprobe("/fake/test.mkv")
+    assert ai.codec == "pcm_s16le"
+    assert ai.sample_rate == 44100
+    assert ai.channels == 2
+    assert ai.bits_per_sample == 16
+    assert abs(ai.duration_sec - 60.0) < 0.01
+
+
+def test_get_audio_info_ffprobe_duration_from_stream():
+    from reprostim.qr.video_audit import get_audio_info_ffprobe
+
+    ffprobe_output = json.dumps(
+        {
+            "streams": [
+                {
+                    "codec_type": "audio",
+                    "codec_name": "aac",
+                    "sample_rate": "48000",
+                    "channels": 1,
+                    "duration": "30.5",
+                }
+            ]
+        }
+    )
+    mock_result = MagicMock(stdout=ffprobe_output, returncode=0)
+    with patch("reprostim.qr.video_audit.subprocess.run", return_value=mock_result):
+        ai = get_audio_info_ffprobe("/fake/test.mkv")
+    assert abs(ai.duration_sec - 30.5) < 0.01
+
+
+def test_get_audio_info_ffprobe_no_audio_streams():
+    from reprostim.qr.video_audit import get_audio_info_ffprobe
+
+    ffprobe_output = json.dumps({"streams": [{"codec_type": "video"}]})
+    mock_result = MagicMock(stdout=ffprobe_output, returncode=0)
+    with patch("reprostim.qr.video_audit.subprocess.run", return_value=mock_result):
+        ai = get_audio_info_ffprobe("/fake/test.mkv")
+    assert ai.codec is None
+
+
+def test_get_audio_info_ffprobe_not_found():
+    from reprostim.qr.video_audit import get_audio_info_ffprobe
+
+    with patch(
+        "reprostim.qr.video_audit.subprocess.run", side_effect=FileNotFoundError
+    ):
+        ai = get_audio_info_ffprobe("/fake/test.mkv")
+    assert ai.codec is None
+
+
+def test_get_audio_info_ffprobe_called_process_error():
+    import subprocess as _subprocess
+
+    from reprostim.qr.video_audit import get_audio_info_ffprobe
+
+    err = _subprocess.CalledProcessError(1, "ffprobe", output="", stderr="error")
+    with patch("reprostim.qr.video_audit.subprocess.run", side_effect=err):
+        ai = get_audio_info_ffprobe("/fake/test.mkv")
+    assert ai.codec is None
+
+
+# ===========================================================================
+# _merge_rec — name mismatch raises ValueError
+# ===========================================================================
+
+
+def test_merge_rec_name_mismatch_raises():
+    with pytest.raises(ValueError, match="Record names do not match"):
+        _merge_rec(_ctx(), _rec(name="a.mkv"), _rec(name="b.mkv"))
+
+
+# ===========================================================================
+# _merge_recs — additional branches
+# ===========================================================================
+
+
+def test_merge_recs_force_empty_recs_cur():
+    """FORCE mode with empty recs_cur returns recs_new directly."""
+    r_old = _rec(name="a.mkv", updated_on=_TS_EARLY)
+    r_new = _rec(name="b.mkv", updated_on=_TS_EARLY)
+    result = _merge_recs(_ctx(mode=VaMode.FORCE), [r_old], [], [r_new])
+    assert result == [r_new]
+
+
+def test_merge_recs_incremental_new_record_added():
+    """Incremental mode: a brand-new record is added alongside existing ones."""
+    r_old = _rec(name="existing.mkv", updated_on="n/a")
+    r_cur = _rec(name="existing.mkv", updated_on=_TS_EARLY)
+    r_new = _rec(name="brand_new.mkv", updated_on=_TS_EARLY)
+    result = _merge_recs(_ctx(mode=VaMode.INCREMENTAL), [r_old], [r_cur], [r_new])
+    names = {r.name for r in result}
+    assert "brand_new.mkv" in names and "existing.mkv" in names
+
+
+# ===========================================================================
+# do_audit_dir — additional branches
+# ===========================================================================
+
+
+def test_do_audit_dir_missing_path(tmp_path):
+    from reprostim.qr.video_audit import do_audit_dir
+
+    assert list(do_audit_dir(_ctx(), str(tmp_path / "missing"))) == []
+
+
+def test_do_audit_dir_not_a_directory(tmp_path):
+    from reprostim.qr.video_audit import do_audit_dir
+
+    f = tmp_path / "file.txt"
+    f.touch()
+    assert list(do_audit_dir(_ctx(), str(f))) == []
+
+
+def test_do_audit_dir_max_counter(tmp_path):
+    from reprostim.qr.video_audit import do_audit_dir
+
+    assert list(do_audit_dir(_ctx(max_counter=0, c_internal=0), str(tmp_path))) == []
+
+
+def test_do_audit_dir_recursive(tmp_path):
+    from reprostim.qr.video_audit import do_audit_dir
+
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    (subdir / "a.mkv").touch()
+    mock_rec = VaRecord(name="a.mkv", path=str(subdir / "a.mkv"), present=True)
+    with patch("reprostim.qr.video_audit.do_audit_file", return_value=iter([mock_rec])):
+        records = list(do_audit_dir(_ctx(recursive=True), str(tmp_path)))
+    assert len(records) == 1 and records[0].name == "a.mkv"
+
+
+# ===========================================================================
+# do_audit_file — skip by base name (after existence check, line 734-736)
+# ===========================================================================
+
+
+def test_do_audit_file_skip_by_base_name(tmp_path):
+    from reprostim.qr.video_audit import do_audit_file
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    ctx = _ctx(skip_names={"test.mkv"})
+    assert list(do_audit_file(ctx, str(mkv))) == []
+
+
+# ===========================================================================
+# do_audit_internal — file and directory paths
+# ===========================================================================
+
+
+def test_do_audit_internal_with_file(tmp_path):
+    from reprostim.qr.video_audit import do_audit_internal
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    mock_rec = VaRecord(name="test.mkv", path=str(mkv), present=True)
+    with patch("reprostim.qr.video_audit.do_audit_file", return_value=iter([mock_rec])):
+        records = list(do_audit_internal(_ctx(), [str(mkv)]))
+    assert len(records) == 1
+
+
+def test_do_audit_internal_with_dir(tmp_path):
+    from reprostim.qr.video_audit import do_audit_internal
+
+    mock_rec = VaRecord(name="a.mkv", path=str(tmp_path / "a.mkv"), present=True)
+    with patch("reprostim.qr.video_audit.do_audit_dir", return_value=iter([mock_rec])):
+        records = list(do_audit_internal(_ctx(), [str(tmp_path)]))
+    assert len(records) == 1
+
+
+def test_do_audit_internal_nonexistent_path(tmp_path):
+    from reprostim.qr.video_audit import do_audit_internal
+
+    records = list(do_audit_internal(_ctx(), [str(tmp_path / "missing")]))
+    assert records == []
+
+
+# ===========================================================================
+# run_ext_nosignal — max_counter / path_mask early exits
+# ===========================================================================
+
+
+def test_run_ext_nosignal_max_counter():
+    from reprostim.qr.video_audit import run_ext_nosignal
+
+    vr = _rec(no_signal_frames="n/a")
+    ctx = _ctx(source={VaSource.NOSIGNAL}, max_counter=0, c_nosignal=0)
+    assert run_ext_nosignal(ctx, vr) is vr
+
+
+def test_run_ext_nosignal_path_mask_no_match():
+    from reprostim.qr.video_audit import run_ext_nosignal
+
+    vr = _rec(no_signal_frames="n/a", path="/data/2024/video.mkv")
+    ctx = _ctx(source={VaSource.NOSIGNAL}, path_mask="*/2025/*")
+    assert run_ext_nosignal(ctx, vr) is vr
+
+
+# ===========================================================================
+# run_ext_nosignal — subprocess execution
+# ===========================================================================
+
+
+def test_run_ext_nosignal_subprocess_success(tmp_path):
+    from reprostim.qr.video_audit import run_ext_nosignal
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    vr = _rec(name="test.mkv", path=str(mkv), no_signal_frames="n/a", start_date="n/a")
+    ctx = _ctx(
+        source={VaSource.NOSIGNAL},
+        nosignal_data_dir=str(tmp_path / "data"),
+        nosignal_log_dir=str(tmp_path / "log"),
+    )
+
+    def _fake_run(cmd, **kwargs):
+        for i, arg in enumerate(cmd):
+            if arg == "--output" and i + 1 < len(cmd):
+                out = cmd[i + 1]
+                os.makedirs(os.path.dirname(out), exist_ok=True)
+                with open(out, "w") as f:
+                    json.dump({"nosignal_rate": 0.05}, f)
+        return MagicMock(returncode=0)
+
+    with patch("reprostim.qr.video_audit.subprocess.run", side_effect=_fake_run):
+        result = run_ext_nosignal(ctx, vr)
+    assert result.no_signal_frames == "5.0"
+
+
+def test_run_ext_nosignal_no_nosignal_rate_key(tmp_path):
+    """JSON output without 'nosignal_rate' sets no_signal_frames to '0.0'."""
+    from reprostim.qr.video_audit import run_ext_nosignal
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    vr = _rec(name="test.mkv", path=str(mkv), no_signal_frames="n/a", start_date="n/a")
+    ctx = _ctx(
+        source={VaSource.NOSIGNAL},
+        nosignal_data_dir=str(tmp_path / "data"),
+        nosignal_log_dir=str(tmp_path / "log"),
+    )
+
+    def _fake_run(cmd, **kwargs):
+        for i, arg in enumerate(cmd):
+            if arg == "--output" and i + 1 < len(cmd):
+                out = cmd[i + 1]
+                os.makedirs(os.path.dirname(out), exist_ok=True)
+                with open(out, "w") as f:
+                    json.dump({"other_key": 42}, f)
+        return MagicMock(returncode=0)
+
+    with patch("reprostim.qr.video_audit.subprocess.run", side_effect=_fake_run):
+        result = run_ext_nosignal(ctx, vr)
+    assert result.no_signal_frames == "0.0"
+
+
+def test_run_ext_nosignal_subprocess_error(tmp_path):
+    """CalledProcessError from detect-noscreen → no_signal_frames unchanged."""
+    import subprocess as _subprocess
+
+    from reprostim.qr.video_audit import run_ext_nosignal
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    vr = _rec(name="test.mkv", path=str(mkv), no_signal_frames="n/a", start_date="n/a")
+    ctx = _ctx(
+        source={VaSource.NOSIGNAL},
+        nosignal_data_dir=str(tmp_path / "data"),
+        nosignal_log_dir=str(tmp_path / "log"),
+    )
+    err = _subprocess.CalledProcessError(1, "reprostim", output="", stderr="")
+    with patch("reprostim.qr.video_audit.subprocess.run", side_effect=err):
+        result = run_ext_nosignal(ctx, vr)
+    assert result.no_signal_frames == "n/a"
+
+
+# ===========================================================================
+# run_ext_qr — max_counter / path_mask early exits
+# ===========================================================================
+
+
+def test_run_ext_qr_max_counter():
+    from reprostim.qr.video_audit import run_ext_qr
+
+    vr = _rec(qr_records_number="n/a")
+    ctx = _ctx(source={VaSource.QR}, max_counter=0, c_qr=0)
+    assert run_ext_qr(ctx, vr) is vr
+
+
+def test_run_ext_qr_path_mask_no_match():
+    from reprostim.qr.video_audit import run_ext_qr
+
+    vr = _rec(qr_records_number="n/a", path="/data/2024/video.mkv")
+    ctx = _ctx(source={VaSource.QR}, path_mask="*/2025/*")
+    assert run_ext_qr(ctx, vr) is vr
+
+
+# ===========================================================================
+# run_ext_qr — subprocess execution
+# ===========================================================================
+
+
+def test_run_ext_qr_subprocess_success(tmp_path):
+    from reprostim.qr.video_audit import run_ext_qr
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    vr = _rec(name="test.mkv", path=str(mkv), qr_records_number="n/a", start_date="n/a")
+    ctx = _ctx(
+        source={VaSource.QR},
+        qr_data_dir=str(tmp_path / "qr_data"),
+        qr_log_dir=str(tmp_path / "qr_log"),
+    )
+    summary_line = '{"type": "ParseSummary", "qr_count": 42}\n'
+
+    def _fake_run(cmd, **kwargs):
+        stdout = kwargs.get("stdout")
+        if stdout is not None and "qr-parse" in cmd:
+            stdout.write(summary_line)
+        return MagicMock(returncode=0)
+
+    with patch("reprostim.qr.video_audit.subprocess.run", side_effect=_fake_run):
+        result = run_ext_qr(ctx, vr)
+    assert result.qr_records_number == "42"
+
+
+def test_run_ext_qr_subprocess_ffmpeg_error(tmp_path):
+    """ffmpeg CalledProcessError → qr_records_number stays at '-2'."""
+    import subprocess as _subprocess
+
+    from reprostim.qr.video_audit import run_ext_qr
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    vr = _rec(name="test.mkv", path=str(mkv), qr_records_number="n/a", start_date="n/a")
+    ctx = _ctx(
+        source={VaSource.QR},
+        qr_data_dir=str(tmp_path / "qr_data"),
+        qr_log_dir=str(tmp_path / "qr_log"),
+    )
+    err = _subprocess.CalledProcessError(1, "ffmpeg", output="", stderr="")
+    with patch("reprostim.qr.video_audit.subprocess.run", side_effect=err):
+        result = run_ext_qr(ctx, vr)
+    assert result.qr_records_number == "-2"
+
+
+def test_run_ext_qr_no_parse_summary(tmp_path):
+    """qr-parse writes nothing → qr_records_number stays at '-1'."""
+    from reprostim.qr.video_audit import run_ext_qr
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    vr = _rec(name="test.mkv", path=str(mkv), qr_records_number="n/a", start_date="n/a")
+    ctx = _ctx(
+        source={VaSource.QR},
+        qr_data_dir=str(tmp_path / "qr_data"),
+        qr_log_dir=str(tmp_path / "qr_log"),
+    )
+
+    def _fake_run(cmd, **kwargs):
+        return MagicMock(returncode=0)
+
+    with patch("reprostim.qr.video_audit.subprocess.run", side_effect=_fake_run):
+        result = run_ext_qr(ctx, vr)
+    assert result.qr_records_number == "-1"
+
+
+# ===========================================================================
+# run_ext_all / do_audit
+# ===========================================================================
+
+
+def test_run_ext_all_with_internal_source():
+    from reprostim.qr.video_audit import run_ext_all
+
+    vr = _rec()
+    ctx = _ctx(source={VaSource.INTERNAL})
+    assert run_ext_all(ctx, vr) is vr
+
+
+def test_do_audit_delegates(tmp_path):
+    from reprostim.qr.video_audit import do_audit
+
+    mkv = tmp_path / "a.mkv"
+    mkv.touch()
+    mock_rec = VaRecord(name="a.mkv", path=str(mkv), present=True)
+    with patch(
+        "reprostim.qr.video_audit.do_audit_internal", return_value=iter([mock_rec])
+    ), patch("reprostim.qr.video_audit.run_ext_all", return_value=mock_rec):
+        records = list(do_audit(_ctx(), [str(tmp_path)]))
+    assert len(records) == 1
+
+
+# ===========================================================================
+# do_ext
+# ===========================================================================
+
+
+def test_do_ext_no_filter_processes_all():
+    """Empty path list → no filter; all records passed to run_ext_all."""
+    from reprostim.qr.video_audit import do_ext
+
+    vr = _rec(name="a.mkv", path="/data/a.mkv")
+    ctx = _ctx(source={VaSource.INTERNAL})
+    with patch("reprostim.qr.video_audit.run_ext_all", return_value=vr) as mock_ext:
+        list(do_ext(ctx, [vr], []))
+    mock_ext.assert_called_once()
+
+
+def test_do_ext_wildcard_processes_all():
+    """Path list ['*'] disables the filter; all records are processed."""
+    from reprostim.qr.video_audit import do_ext
+
+    vr = _rec(name="a.mkv", path="/data/a.mkv")
+    ctx = _ctx(source={VaSource.INTERNAL})
+    with patch("reprostim.qr.video_audit.run_ext_all", return_value=vr) as mock_ext:
+        list(do_ext(ctx, [vr], ["*"]))
+    mock_ext.assert_called_once()
+
+
+def test_do_ext_filter_by_file(tmp_path):
+    """Record path matches an explicit file path in the filter."""
+    from reprostim.qr.video_audit import do_ext
+
+    mkv = tmp_path / "a.mkv"
+    mkv.touch()
+    vr = _rec(name="a.mkv", path=str(mkv))
+    ctx = _ctx(source={VaSource.INTERNAL})
+    with patch("reprostim.qr.video_audit.run_ext_all", return_value=vr) as mock_ext:
+        list(do_ext(ctx, [vr], [str(mkv)]))
+    mock_ext.assert_called_once()
+
+
+def test_do_ext_filter_by_directory(tmp_path):
+    """Record path starts with a directory in the filter."""
+    from reprostim.qr.video_audit import do_ext
+
+    mkv = tmp_path / "a.mkv"
+    mkv.touch()
+    vr = _rec(name="a.mkv", path=str(mkv))
+    ctx = _ctx(source={VaSource.INTERNAL})
+    with patch("reprostim.qr.video_audit.run_ext_all", return_value=vr) as mock_ext:
+        list(do_ext(ctx, [vr], [str(tmp_path)]))
+    mock_ext.assert_called_once()
+
+
+def test_do_ext_no_filter_match_yields_unchanged(tmp_path):
+    """Record not matching any filter path is yielded unchanged without processing."""
+    from reprostim.qr.video_audit import do_ext
+
+    other = tmp_path / "other"
+    other.mkdir()
+    vr = _rec(name="a.mkv", path="/data/a.mkv")
+    ctx = _ctx(source={VaSource.INTERNAL})
+    with patch("reprostim.qr.video_audit.run_ext_all") as mock_ext:
+        result = list(do_ext(ctx, [vr], [str(other)]))
+    mock_ext.assert_not_called()
+    assert result == [vr]
+
+
+# ===========================================================================
+# get_file_video_audit — Timeout and generic exception fallbacks
+# ===========================================================================
+
+
+def test_get_file_video_audit_timeout_falls_back(tmp_path):
+    from filelock import Timeout
+
+    from reprostim.qr.video_audit import _tsv_cache, get_file_video_audit
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    tsv = str(tmp_path / "videos.tsv")
+    _save_tsv([_rec(name="test.mkv", path=str(mkv))], tsv)
+    _tsv_cache.pop(tsv, None)
+    fallback = _rec(name="test.mkv", path=str(mkv))
+    with patch(
+        "reprostim.qr.video_audit._get_tsv_records", side_effect=Timeout(tsv)
+    ), patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.do_audit_file", return_value=iter([fallback])
+    ):
+        result = get_file_video_audit(str(mkv), path_tsv=tsv, use_lock=False)
+    assert result is not None and result.name == "test.mkv"
+
+
+def test_get_file_video_audit_exception_falls_back(tmp_path):
+    from reprostim.qr.video_audit import _tsv_cache, get_file_video_audit
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    tsv = str(tmp_path / "videos.tsv")
+    _save_tsv([_rec(name="test.mkv", path=str(mkv))], tsv)
+    _tsv_cache.pop(tsv, None)
+    fallback = _rec(name="test.mkv", path=str(mkv))
+    with patch(
+        "reprostim.qr.video_audit._get_tsv_records", side_effect=IOError("disk error")
+    ), patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.do_audit_file", return_value=iter([fallback])
+    ):
+        result = get_file_video_audit(str(mkv), path_tsv=tsv, use_lock=False)
+    assert result is not None and result.name == "test.mkv"
+
+
+# ===========================================================================
+# _parse_rec_datetime — ValueError path
+# ===========================================================================
+
+
+def test_parse_rec_datetime_invalid_format():
+    """Malformed strings return None rather than raising ValueError."""
+    assert _parse_rec_datetime("not-a-date", "not-a-time") is None
+
+
+# ===========================================================================
+# find_video_audit_by_timerange — skip conditions
+# ===========================================================================
+
+
+def test_find_video_audit_skip_not_present(tmp_path):
+    """Records with present=False are excluded from results."""
+    r = VaRecord(
+        name="a.mkv",
+        path="/data/a.mkv",
+        present=False,
+        complete=True,
+        start_date="2025-01-01",
+        start_time="10:00:00.000",
+        end_date="2025-01-01",
+        end_time="11:00:00.000",
+    )
+    path = _tsv_with(tmp_path, [r])
+    result = find_video_audit_by_timerange(
+        path,
+        datetime(2025, 1, 1, 9, 0),
+        datetime(2025, 1, 1, 12, 0),
+        use_lock=False,
+    )
+    assert result == []
+
+
+def test_find_video_audit_skip_not_complete(tmp_path):
+    """Records with complete=False are excluded from results."""
+    r = VaRecord(
+        name="a.mkv",
+        path="/data/a.mkv",
+        present=True,
+        complete=False,
+        start_date="2025-01-01",
+        start_time="10:00:00.000",
+        end_date="2025-01-01",
+        end_time="11:00:00.000",
+    )
+    path = _tsv_with(tmp_path, [r])
+    result = find_video_audit_by_timerange(
+        path,
+        datetime(2025, 1, 1, 9, 0),
+        datetime(2025, 1, 1, 12, 0),
+        use_lock=False,
+    )
+    assert result == []
+
+
+def test_find_video_audit_skip_na_start(tmp_path):
+    """Records with n/a start_date are excluded."""
+    r = VaRecord(
+        name="a.mkv",
+        path="/data/a.mkv",
+        present=True,
+        complete=True,
+        start_date="n/a",
+        start_time="10:00:00.000",
+        end_date="2025-01-01",
+        end_time="11:00:00.000",
+    )
+    path = _tsv_with(tmp_path, [r])
+    result = find_video_audit_by_timerange(
+        path,
+        datetime(2025, 1, 1, 9, 0),
+        datetime(2025, 1, 1, 12, 0),
+        use_lock=False,
+    )
+    assert result == []
+
+
+def test_find_video_audit_skip_na_end(tmp_path):
+    """Records with n/a end_date are excluded (end is required for intersection)."""
+    r = VaRecord(
+        name="a.mkv",
+        path="/data/a.mkv",
+        present=True,
+        complete=True,
+        start_date="2025-01-01",
+        start_time="10:00:00.000",
+        end_date="n/a",
+        end_time="n/a",
+    )
+    path = _tsv_with(tmp_path, [r])
+    result = find_video_audit_by_timerange(
+        path,
+        datetime(2025, 1, 1, 9, 0),
+        datetime(2025, 1, 1, 12, 0),
+        use_lock=False,
+    )
+    assert result == []
+
+
+# ===========================================================================
+# do_main — additional branches
+# ===========================================================================
+
+
+def test_do_main_ffprobe_missing_still_returns_zero(tmp_path):
+    """When ffprobe is absent do_main emits an error message but returns 0."""
+    from reprostim.qr.video_audit import do_main
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    tsv = str(tmp_path / "videos.tsv")
+    mock_rec = _rec(name="test.mkv", path=str(mkv))
+    messages = []
+    with patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.check_ffprobe", return_value=False
+    ), patch("reprostim.qr.video_audit.do_audit", return_value=iter([mock_rec])):
+        rc = do_main([str(tmp_path)], tsv, out_func=messages.append)
+    assert rc == 0
+    assert any("ffprobe" in m for m in messages)
+
+
+def test_do_main_verbose_prints_json(tmp_path):
+    """verbose=True causes each record to be printed as JSON via out_func."""
+    from reprostim.qr.video_audit import do_main
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    tsv = str(tmp_path / "videos.tsv")
+    mock_rec = _rec(name="test.mkv", path=str(mkv))
+    outputs = []
+    with patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.check_ffprobe", return_value=True
+    ), patch("reprostim.qr.video_audit.do_audit", return_value=iter([mock_rec])):
+        do_main([str(tmp_path)], tsv, verbose=True, out_func=outputs.append)
+    assert len(outputs) >= 1
+
+
+def test_do_main_incremental_merges_existing(tmp_path):
+    """Incremental mode loads an existing TSV and merges new records into it."""
+    from reprostim.qr.video_audit import _load_tsv, do_main
+
+    mkv = tmp_path / "new.mkv"
+    mkv.touch()
+    tsv = str(tmp_path / "videos.tsv")
+    existing = _rec(name="old.mkv", path=str(tmp_path / "old.mkv"))
+    _save_tsv([existing], tsv)
+    new_rec = _rec(name="new.mkv", path=str(mkv))
+    with patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.check_ffprobe", return_value=True
+    ), patch("reprostim.qr.video_audit.do_audit", return_value=iter([new_rec])):
+        rc = do_main([str(tmp_path)], tsv, mode=VaMode.INCREMENTAL)
+    assert rc == 0
+    names = {r.name for r in _load_tsv(tsv)}
+    assert "old.mkv" in names and "new.mkv" in names

--- a/tests/qr/test_video_audit.py
+++ b/tests/qr/test_video_audit.py
@@ -4,7 +4,7 @@
 
 """CLI tests for ``reprostim video-audit``.
 
-Covers: --nosignal-opts, --qr-opts and their default behaviour.
+Covers: --nosignal-opts, --qr-opts, --config and their default behaviour.
 ``do_main`` is patched so no real video processing takes place.
 """
 
@@ -110,3 +110,81 @@ def test_qr_opts_default_is_none(tmp_mkv):
         result = _invoke([tmp_mkv])
     assert result.exit_code == 0
     assert mock_do_main.call_args.kwargs["qr_opts"] is None
+
+
+# ---------------------------------------------------------------------------
+# -c / --config
+# ---------------------------------------------------------------------------
+
+
+def test_config_nosignal_opts(tmp_path, tmp_mkv):
+    """nosignal-opts from config file is forwarded to do_main as nosignal_opts."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("nosignal-opts: '--number-of-checks 300 --threshold 0.8'\n")
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["-c", str(cfg), tmp_mkv])
+    assert result.exit_code == 0
+    assert (
+        mock_do_main.call_args.kwargs["nosignal_opts"]
+        == "--number-of-checks 300 --threshold 0.8"
+    )
+
+
+def test_config_qr_opts(tmp_path, tmp_mkv):
+    """qr-opts from config file is forwarded to do_main as qr_opts."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("qr-opts: '--skip 3 --std-threshold 20'\n")
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["-c", str(cfg), tmp_mkv])
+    assert result.exit_code == 0
+    assert mock_do_main.call_args.kwargs["qr_opts"] == "--skip 3 --std-threshold 20"
+
+
+def test_config_cli_overrides_nosignal_opts(tmp_path, tmp_mkv):
+    """Explicit -n on CLI takes precedence over nosignal-opts in config."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("nosignal-opts: '--number-of-checks 300'\n")
+    cli_opts = "--number-of-checks 999"
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["-c", str(cfg), "-n", cli_opts, tmp_mkv])
+    assert result.exit_code == 0
+    assert mock_do_main.call_args.kwargs["nosignal_opts"] == cli_opts
+
+
+def test_config_cli_overrides_qr_opts(tmp_path, tmp_mkv):
+    """Explicit -q on CLI takes precedence over qr-opts in config."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("qr-opts: '--skip 3'\n")
+    cli_opts = "--skip 99"
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["-c", str(cfg), "-q", cli_opts, tmp_mkv])
+    assert result.exit_code == 0
+    assert mock_do_main.call_args.kwargs["qr_opts"] == cli_opts
+
+
+def test_config_other_keys(tmp_path, tmp_mkv):
+    """mode, recursive, and max-files from config are passed correctly to do_main."""
+    from reprostim.qr.video_audit import VaMode
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("mode: full\nrecursive: true\nmax-files: 5\n")
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["-c", str(cfg), tmp_mkv])
+    assert result.exit_code == 0
+    args = mock_do_main.call_args.args
+    assert args[2] is True  # recursive
+    assert args[3] == VaMode.FULL  # mode
+    assert args[5] == 5  # max_files
+
+
+def test_config_audit_src_list(tmp_path, tmp_mkv):
+    """audit-src list in config is converted to a set of VaSource values."""
+    from reprostim.qr.video_audit import VaSource
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("audit-src:\n  - internal\n  - qr\n")
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["-c", str(cfg), tmp_mkv])
+    assert result.exit_code == 0
+    va_src = mock_do_main.call_args.args[4]
+    assert va_src == {VaSource.INTERNAL, VaSource.QR}

--- a/tests/qr/test_video_audit.py
+++ b/tests/qr/test_video_audit.py
@@ -8,14 +8,72 @@ Covers: --nosignal-opts, --qr-opts, --config and their default behaviour.
 ``do_main`` is patched so no real video processing takes place.
 """
 
-from unittest.mock import patch
+import json
+import os
+
+# import subprocess
+from datetime import datetime
+from unittest.mock import MagicMock, patch
 
 import click.testing
 import pytest
 
 from reprostim.cli.cmd_video_audit import video_audit
+from reprostim.qr.video_audit import (
+    VaContext,
+    VaMode,
+    VaRecord,
+    VaSource,
+    _compare_rec_ts,
+    _load_tsv,
+    _match_recs,
+    _merge_rec,
+    _merge_recs,
+    _parse_rec_datetime,
+    _save_tsv,
+    check_coherent,
+    check_ffprobe,
+    find_metadata_json,
+    find_video_audit_by_timerange,
+    format_date,
+    format_duration,
+    format_time,
+    iter_metadata_json,
+)
 
 runner = click.testing.CliRunner()
+
+# Timestamp constants used across merge/compare tests
+_TS_EARLY = "2025-01-01 00:00:00.000000"
+_TS_LATE = "2025-01-01 01:00:00.000000"
+
+# Env var required by do_main / get_file_video_audit
+_ENV = {"REPROSTIM_LOG_LEVEL": "INFO"}
+
+
+def _rec(name="a.mkv", **kw) -> VaRecord:
+    """Minimal VaRecord for unit tests."""
+    return VaRecord(name=name, path=kw.pop("path", f"/data/{name}"), **kw)
+
+
+def _ctx(**kw) -> VaContext:
+    """VaContext with safe defaults for unit tests."""
+    defaults = dict(
+        c_internal=0,
+        c_nosignal=0,
+        c_qr=0,
+        log_level="INFO",
+        max_counter=-1,
+        mode=VaMode.INCREMENTAL,
+        source={VaSource.INTERNAL},
+        recursive=False,
+        path_mask=None,
+        skip_names=None,
+        updated_paths=set(),
+    )
+    defaults.update(kw)
+    return VaContext(**defaults)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -179,8 +237,6 @@ def test_config_other_keys(tmp_path, tmp_mkv):
 
 def test_config_audit_src_list(tmp_path, tmp_mkv):
     """audit-src list in config is converted to a set of VaSource values."""
-    from reprostim.qr.video_audit import VaSource
-
     cfg = tmp_path / "config.yaml"
     cfg.write_text("audit-src:\n  - internal\n  - qr\n")
     with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
@@ -188,3 +244,776 @@ def test_config_audit_src_list(tmp_path, tmp_mkv):
     assert result.exit_code == 0
     va_src = mock_do_main.call_args.args[4]
     assert va_src == {VaSource.INTERNAL, VaSource.QR}
+
+
+# ---------------------------------------------------------------------------
+# CLI: config audit-src scalar string / --mode / unknown mode
+# ---------------------------------------------------------------------------
+
+
+def test_config_audit_src_scalar_string(tmp_path, tmp_mkv):
+    """Config audit-src as a scalar string is wrapped into a single-element tuple."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("audit-src: qr\n")
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["-c", str(cfg), tmp_mkv])
+    assert result.exit_code == 0
+    va_src = mock_do_main.call_args.args[4]
+    assert va_src == {VaSource.QR}
+
+
+def test_mode_full_passed_to_do_main(tmp_mkv):
+    """--mode full passes VaMode.FULL as the mode positional arg to do_main."""
+    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+        result = _invoke(["--mode", "full", tmp_mkv])
+    assert result.exit_code == 0
+    assert mock_do_main.call_args.args[3] == VaMode.FULL
+
+
+def test_unknown_mode_click_error(tmp_mkv):
+    """An invalid --mode value causes Click to exit with a non-zero code."""
+    result = runner.invoke(video_audit, ["--mode", "bogus", tmp_mkv])
+    assert result.exit_code != 0
+
+
+# ===========================================================================
+# format_duration
+# ===========================================================================
+
+
+def test_format_duration_none():
+    assert format_duration(None) == "n/a"
+
+
+def test_format_duration_zero():
+    assert format_duration(0) == "00:00:00.000"
+
+
+def test_format_duration_sub_minute():
+    assert format_duration(45.5) == "00:00:45.500"
+
+
+def test_format_duration_hours():
+    assert format_duration(3723.0) == "01:02:03.000"
+
+
+# ===========================================================================
+# format_date / format_time
+# ===========================================================================
+
+
+def test_format_date_none():
+    assert format_date(None) == "n/a"
+
+
+def test_format_date_known():
+    assert format_date(datetime(2025, 3, 15, 10, 30, 45)) == "2025-03-15"
+
+
+def test_format_time_none():
+    assert format_time(None) == "n/a"
+
+
+def test_format_time_known():
+    assert format_time(datetime(2025, 3, 15, 10, 30, 45, 123000)) == "10:30:45.123"
+
+
+# ===========================================================================
+# check_coherent
+# ===========================================================================
+
+
+def _coherent_rec(**kw) -> VaRecord:
+    defaults = dict(
+        path="/data/test.mkv",
+        name="test.mkv",
+        present=True,
+        complete=True,
+        start_date="2025-01-01",
+        start_time="00:00:00.000",
+        end_date="2025-01-01",
+        end_time="00:01:00.000",
+        video_res_detected="1920x1080",
+        video_fps_detected="30.0",
+        video_res_recorded="1920x1080",
+        video_fps_recorded="30.0",
+        duration="60.0",
+        duration_h="00:01:00.000",
+    )
+    defaults.update(kw)
+    return VaRecord(**defaults)
+
+
+def test_check_coherent_valid():
+    assert check_coherent(_coherent_rec()) is True
+
+
+def test_check_coherent_not_present():
+    assert check_coherent(_coherent_rec(present=False)) is False
+
+
+def test_check_coherent_not_complete():
+    assert check_coherent(_coherent_rec(complete=False)) is False
+
+
+def test_check_coherent_missing_start():
+    assert check_coherent(_coherent_rec(start_date="n/a")) is False
+
+
+def test_check_coherent_missing_end():
+    assert check_coherent(_coherent_rec(end_date="n/a")) is False
+
+
+def test_check_coherent_missing_detected_res():
+    assert check_coherent(_coherent_rec(video_res_detected="n/a")) is False
+
+
+def test_check_coherent_missing_recorded_res():
+    assert check_coherent(_coherent_rec(video_res_recorded="n/a")) is False
+
+
+def test_check_coherent_missing_duration():
+    assert check_coherent(_coherent_rec(duration="n/a")) is False
+
+
+def test_check_coherent_res_mismatch():
+    assert check_coherent(_coherent_rec(video_res_detected="1280x720")) is False
+
+
+def test_check_coherent_fps_mismatch():
+    assert check_coherent(_coherent_rec(video_fps_detected="25.0")) is False
+
+
+# ===========================================================================
+# check_ffprobe
+# ===========================================================================
+
+
+def test_check_ffprobe_available():
+    with patch("reprostim.qr.video_audit.subprocess.run"):
+        assert check_ffprobe() is True
+
+
+def test_check_ffprobe_not_found():
+    with patch(
+        "reprostim.qr.video_audit.subprocess.run", side_effect=FileNotFoundError
+    ):
+        assert check_ffprobe() is False
+
+
+# ===========================================================================
+# _compare_rec_ts
+# ===========================================================================
+
+
+def test_compare_rec_ts_both_na():
+    assert _compare_rec_ts(_rec(updated_on="n/a"), _rec(updated_on="n/a")) == 0
+
+
+def test_compare_rec_ts_equal():
+    assert _compare_rec_ts(_rec(updated_on=_TS_EARLY), _rec(updated_on=_TS_EARLY)) == 0
+
+
+def test_compare_rec_ts_left_na():
+    assert _compare_rec_ts(_rec(updated_on="n/a"), _rec(updated_on=_TS_EARLY)) == -1
+
+
+def test_compare_rec_ts_right_na():
+    assert _compare_rec_ts(_rec(updated_on=_TS_EARLY), _rec(updated_on="n/a")) == 1
+
+
+def test_compare_rec_ts_earlier():
+    assert _compare_rec_ts(_rec(updated_on=_TS_EARLY), _rec(updated_on=_TS_LATE)) == -1
+
+
+def test_compare_rec_ts_later():
+    assert _compare_rec_ts(_rec(updated_on=_TS_LATE), _rec(updated_on=_TS_EARLY)) == 1
+
+
+# ===========================================================================
+# _match_recs
+# ===========================================================================
+
+
+def test_match_recs_identical():
+    r = _rec()
+    assert _match_recs([r], [r]) is True
+
+
+def test_match_recs_different_length():
+    assert _match_recs([_rec()], []) is False
+
+
+def test_match_recs_different_content():
+    assert _match_recs([_rec(name="a.mkv")], [_rec(name="b.mkv")]) is False
+
+
+# ===========================================================================
+# _merge_rec
+# ===========================================================================
+
+
+def test_merge_rec_all_equal_returns_new():
+    r_cur = _rec(
+        updated_on=_TS_EARLY, no_signal_updated_on=_TS_EARLY, qr_updated_on=_TS_EARLY
+    )
+    r_new = _rec(
+        updated_on=_TS_EARLY, no_signal_updated_on=_TS_EARLY, qr_updated_on=_TS_EARLY
+    )
+    result = _merge_rec(_ctx(), r_cur, r_new)
+    assert result is r_new
+
+
+def test_merge_rec_newer_internal_in_new():
+    r_cur = _rec(updated_on=_TS_EARLY, no_signal_updated_on="n/a", qr_updated_on="n/a")
+    r_new = _rec(updated_on=_TS_LATE, no_signal_updated_on="n/a", qr_updated_on="n/a")
+    result = _merge_rec(_ctx(), r_cur, r_new)
+    assert result.updated_on == _TS_LATE
+
+
+def test_merge_rec_newer_nosignal_in_cur():
+    r_cur = _rec(
+        no_signal_frames="5.0",
+        no_signal_updated_on=_TS_LATE,
+        updated_on=_TS_EARLY,
+        qr_updated_on="n/a",
+    )
+    r_new = _rec(
+        no_signal_frames="9.0",
+        no_signal_updated_on=_TS_EARLY,
+        updated_on=_TS_LATE,
+        qr_updated_on="n/a",
+    )
+    result = _merge_rec(_ctx(), r_cur, r_new)
+    assert result.no_signal_frames == "5.0"
+
+
+def test_merge_rec_newer_qr_in_new():
+    r_cur = _rec(
+        qr_records_number="10",
+        qr_updated_on=_TS_EARLY,
+        updated_on="n/a",
+        no_signal_updated_on="n/a",
+    )
+    r_new = _rec(
+        qr_records_number="20",
+        qr_updated_on=_TS_LATE,
+        updated_on="n/a",
+        no_signal_updated_on="n/a",
+    )
+    result = _merge_rec(_ctx(), r_cur, r_new)
+    assert result.qr_records_number == "20"
+
+
+# ===========================================================================
+# _merge_recs
+# ===========================================================================
+
+
+def test_merge_recs_no_change_skips_merge():
+    """When recs0 == recs_cur the merge step is skipped and recs_new returned as-is."""
+    r = _rec(updated_on=_TS_EARLY)
+    result = _merge_recs(_ctx(), [r], [r], [r])
+    assert result == [r]
+
+
+def test_merge_recs_full_mode_overrides():
+    r_old = _rec(name="a.mkv", updated_on=_TS_EARLY)
+    r_cur = _rec(name="a.mkv", updated_on=_TS_LATE)
+    r_new = _rec(name="b.mkv", updated_on=_TS_EARLY)
+    result = _merge_recs(_ctx(mode=VaMode.FULL), [r_old], [r_cur], [r_new])
+    assert result == [r_new]
+
+
+def test_merge_recs_force_mode_merges_all():
+    r_old = _rec(name="a.mkv", updated_on=_TS_EARLY)
+    r_cur = _rec(name="a.mkv", updated_on=_TS_LATE)
+    r_new = _rec(name="b.mkv", updated_on=_TS_EARLY)
+    result = _merge_recs(_ctx(mode=VaMode.FORCE), [r_old], [r_cur], [r_new])
+    names = {r.name for r in result}
+    assert "a.mkv" in names and "b.mkv" in names
+
+
+def test_merge_recs_incremental_timestamp_wins():
+    """In incremental mode the newer timestamp between cur and new wins."""
+    r_old = _rec(name="a.mkv", updated_on=_TS_EARLY)
+    r_cur = _rec(name="a.mkv", updated_on=_TS_LATE)
+    r_new = _rec(name="a.mkv", updated_on=_TS_EARLY)
+    result = _merge_recs(_ctx(mode=VaMode.INCREMENTAL), [r_old], [r_cur], [r_new])
+    assert result[0].updated_on == _TS_LATE
+
+
+# ===========================================================================
+# TSV I/O
+# ===========================================================================
+
+
+def test_save_load_tsv_roundtrip(tmp_path):
+    recs = [_rec(name="a.mkv"), _rec(name="b.mkv")]
+    path = str(tmp_path / "videos.tsv")
+    _save_tsv(recs, path)
+    loaded = _load_tsv(path)
+    assert [r.name for r in loaded] == ["a.mkv", "b.mkv"]
+
+
+def test_get_tsv_records_with_lock(tmp_path):
+    from reprostim.qr.video_audit import _get_tsv_records, _tsv_cache
+
+    path = str(tmp_path / "videos.tsv")
+    _save_tsv([_rec(name="x.mkv")], path)
+    _tsv_cache.pop(path, None)
+    assert _get_tsv_records(path, use_lock=True)[0].name == "x.mkv"
+
+
+def test_get_tsv_records_no_lock(tmp_path):
+    from reprostim.qr.video_audit import _get_tsv_records, _tsv_cache
+
+    path = str(tmp_path / "videos.tsv")
+    _save_tsv([_rec(name="y.mkv")], path)
+    _tsv_cache.pop(path, None)
+    assert _get_tsv_records(path, use_lock=False)[0].name == "y.mkv"
+
+
+def test_get_tsv_records_cached(tmp_path):
+    from reprostim.qr.video_audit import _get_tsv_records, _tsv_cache
+
+    path = str(tmp_path / "videos.tsv")
+    _save_tsv([_rec(name="z.mkv")], path)
+    _tsv_cache.pop(path, None)
+    _get_tsv_records(path, cached=True)
+    _save_tsv([_rec(name="new.mkv")], path)
+    cached = _get_tsv_records(path, cached=True)
+    assert cached[0].name == "z.mkv"
+
+
+# ===========================================================================
+# iter_metadata_json / find_metadata_json
+# ===========================================================================
+
+
+def _write_log(tmp_path, entries):
+    log = tmp_path / "test.log"
+    lines = [
+        f"PREFIX REPROSTIM-METADATA-JSON: {json.dumps(e)} :REPROSTIM-METADATA-JSON\n"
+        for e in entries
+    ]
+    log.write_text("".join(lines))
+    return str(log)
+
+
+def test_iter_metadata_json_valid(tmp_path):
+    path = _write_log(tmp_path, [{"type": "session_begin", "cx": 1920}])
+    results = list(iter_metadata_json(path))
+    assert len(results) == 1
+    assert results[0]["cx"] == 1920
+
+
+def test_iter_metadata_json_missing_file(tmp_path):
+    assert list(iter_metadata_json(str(tmp_path / "missing.log"))) == []
+
+
+def test_find_metadata_json_found(tmp_path):
+    path = _write_log(tmp_path, [{"type": "session_begin", "cx": 1920}])
+    result = find_metadata_json(path, "type", "session_begin")
+    assert result is not None and result["cx"] == 1920
+
+
+def test_find_metadata_json_not_found(tmp_path):
+    log = tmp_path / "empty.log"
+    log.write_text("no metadata here\n")
+    assert find_metadata_json(str(log), "type", "session_begin") is None
+
+
+# ===========================================================================
+# _parse_rec_datetime
+# ===========================================================================
+
+
+def test_parse_rec_datetime_valid():
+    dt = _parse_rec_datetime("2025-01-15", "10:30:45.123")
+    assert dt is not None and dt.year == 2025 and dt.hour == 10
+
+
+def test_parse_rec_datetime_na_date():
+    assert _parse_rec_datetime("n/a", "10:30:45.123") is None
+
+
+def test_parse_rec_datetime_na_time():
+    assert _parse_rec_datetime("2025-01-15", "n/a") is None
+
+
+# ===========================================================================
+# find_video_audit_by_timerange
+# ===========================================================================
+
+
+def _range_rec(name, start: datetime, end: datetime) -> VaRecord:
+    return VaRecord(
+        name=name,
+        path=f"/data/{name}",
+        present=True,
+        complete=True,
+        start_date=start.strftime("%Y-%m-%d"),
+        start_time=start.strftime("%H:%M:%S.") + f"{start.microsecond // 1000:03d}",
+        end_date=end.strftime("%Y-%m-%d"),
+        end_time=end.strftime("%H:%M:%S.") + f"{end.microsecond // 1000:03d}",
+    )
+
+
+def _tsv_with(tmp_path, records):
+    path = str(tmp_path / "videos.tsv")
+    _save_tsv(records, path)
+    return path
+
+
+def test_find_video_audit_intersects(tmp_path):
+    r = _range_rec("a.mkv", datetime(2025, 1, 1, 10, 0), datetime(2025, 1, 1, 11, 0))
+    path = _tsv_with(tmp_path, [r])
+    result = find_video_audit_by_timerange(
+        path, datetime(2025, 1, 1, 10, 30), datetime(2025, 1, 1, 12, 0), use_lock=False
+    )
+    assert len(result) == 1 and result[0].name == "a.mkv"
+
+
+def test_find_video_audit_before_range(tmp_path):
+    r = _range_rec("a.mkv", datetime(2025, 1, 1, 8, 0), datetime(2025, 1, 1, 9, 0))
+    path = _tsv_with(tmp_path, [r])
+    result = find_video_audit_by_timerange(
+        path, datetime(2025, 1, 1, 10, 0), datetime(2025, 1, 1, 11, 0), use_lock=False
+    )
+    assert result == []
+
+
+def test_find_video_audit_after_range(tmp_path):
+    r = _range_rec("a.mkv", datetime(2025, 1, 1, 12, 0), datetime(2025, 1, 1, 13, 0))
+    path = _tsv_with(tmp_path, [r])
+    result = find_video_audit_by_timerange(
+        path, datetime(2025, 1, 1, 10, 0), datetime(2025, 1, 1, 11, 0), use_lock=False
+    )
+    assert result == []
+
+
+def test_find_video_audit_sorted_ascending(tmp_path):
+    r1 = _range_rec("b.mkv", datetime(2025, 1, 1, 11, 0), datetime(2025, 1, 1, 12, 0))
+    r2 = _range_rec("a.mkv", datetime(2025, 1, 1, 10, 0), datetime(2025, 1, 1, 11, 30))
+    path = _tsv_with(tmp_path, [r1, r2])
+    result = find_video_audit_by_timerange(
+        path, datetime(2025, 1, 1, 9, 0), datetime(2025, 1, 1, 13, 0), use_lock=False
+    )
+    assert result[0].name == "a.mkv" and result[1].name == "b.mkv"
+
+
+# ===========================================================================
+# _build_dated_path
+# ===========================================================================
+
+
+def test_build_dated_path_with_date(tmp_path):
+    from reprostim.qr.video_audit import _build_dated_path
+
+    r = _rec(name="video.mkv", path="/data/video.mkv", start_date="2025-03-15")
+    result = _build_dated_path(r, str(tmp_path), "nosignal.json")
+    assert "2025" in result and "03" in result
+    assert result.endswith("video.mkv.nosignal.json")
+
+
+def test_build_dated_path_na_date(tmp_path):
+    from reprostim.qr.video_audit import _build_dated_path
+
+    r = _rec(name="video.mkv", path="/data/video.mkv", start_date="n/a")
+    result = _build_dated_path(r, str(tmp_path), "nosignal.json")
+    assert result.endswith("video.mkv.nosignal.json")
+    assert "n/a" not in result
+
+
+# ===========================================================================
+# do_audit_file
+# ===========================================================================
+
+
+def test_do_audit_file_max_counter(tmp_path):
+    from reprostim.qr.video_audit import do_audit_file
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    assert list(do_audit_file(_ctx(max_counter=0, c_internal=0), str(mkv))) == []
+
+
+def test_do_audit_file_skip_by_path(tmp_path):
+    from reprostim.qr.video_audit import do_audit_file
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    assert list(do_audit_file(_ctx(skip_names={str(mkv)}), str(mkv))) == []
+
+
+def test_do_audit_file_path_mask_no_match(tmp_path):
+    from reprostim.qr.video_audit import do_audit_file
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    assert list(do_audit_file(_ctx(path_mask="*/other/*.mkv"), str(mkv))) == []
+
+
+def test_do_audit_file_missing_file(tmp_path):
+    from reprostim.qr.video_audit import do_audit_file
+
+    records = list(do_audit_file(_ctx(), str(tmp_path / "missing.mkv")))
+    assert len(records) == 1 and records[0].present is False
+
+
+def test_do_audit_file_happy_path(tmp_path):
+    from reprostim.qr.video_audit import do_audit_file
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    mock_vi = MagicMock(duration_sec=60.0, size_mb=100.0, rate_mbpm=200.0)
+    mock_vti = MagicMock(
+        start_time=datetime(2025, 1, 1, 10, 0, 0),
+        end_time=datetime(2025, 1, 1, 10, 1, 0),
+    )
+    mock_ps = MagicMock(
+        video_duration=60.0,
+        video_frame_width=1920,
+        video_frame_height=1080,
+        video_frame_rate=30.0,
+    )
+    mock_ai = MagicMock(
+        sample_rate=44100,
+        channels=2,
+        codec="pcm_s16le",
+        bits_per_sample=16,
+        duration_sec=60.0,
+    )
+    sb = {"frameRate": "30.0", "cx": 1920, "cy": 1080}
+    with patch("reprostim.qr.video_audit.find_metadata_json", return_value=sb), patch(
+        "reprostim.qr.video_audit.do_info_file", return_value=(mock_vi, mock_vti)
+    ), patch("reprostim.qr.video_audit.do_parse", return_value=iter([mock_ps])), patch(
+        "reprostim.qr.video_audit.get_audio_info_ffprobe", return_value=mock_ai
+    ):
+        records = list(do_audit_file(_ctx(), str(mkv)))
+    assert len(records) == 1
+    vr = records[0]
+    assert vr.present is True
+    assert vr.name == "test.mkv"
+    assert vr.video_res_detected == "1920x1080"
+    assert vr.duration == "60.0"
+    assert vr.updated_on != "n/a"
+
+
+# ===========================================================================
+# do_audit_dir / do_audit_internal
+# ===========================================================================
+
+
+def test_do_audit_dir_yields_mkv_files(tmp_path):
+    from reprostim.qr.video_audit import do_audit_dir
+
+    (tmp_path / "a.mkv").touch()
+    (tmp_path / "b.txt").touch()
+    mock_rec = VaRecord(name="a.mkv", path=str(tmp_path / "a.mkv"), present=True)
+    with patch("reprostim.qr.video_audit.do_audit_file", return_value=iter([mock_rec])):
+        records = list(do_audit_dir(_ctx(), str(tmp_path)))
+    assert len(records) == 1 and records[0].name == "a.mkv"
+
+
+def test_do_audit_internal_skips_rerun_for_na():
+    from reprostim.qr.video_audit import do_audit_internal
+
+    assert list(do_audit_internal(_ctx(mode=VaMode.RERUN_FOR_NA), [])) == []
+
+
+def test_do_audit_internal_skips_reset_to_na():
+    from reprostim.qr.video_audit import do_audit_internal
+
+    assert list(do_audit_internal(_ctx(mode=VaMode.RESET_TO_NA), [])) == []
+
+
+def test_do_audit_internal_skips_wrong_source():
+    from reprostim.qr.video_audit import do_audit_internal
+
+    assert list(do_audit_internal(_ctx(source={VaSource.QR}), [])) == []
+
+
+# ===========================================================================
+# run_ext_nosignal — early-exit paths
+# ===========================================================================
+
+
+def test_run_ext_nosignal_wrong_source():
+    from reprostim.qr.video_audit import run_ext_nosignal
+
+    vr = _rec()
+    assert run_ext_nosignal(_ctx(source={VaSource.QR}), vr) is vr
+
+
+def test_run_ext_nosignal_reset_to_na_resets_value():
+    from reprostim.qr.video_audit import run_ext_nosignal
+
+    vr = _rec(no_signal_frames="5.0")
+    result = run_ext_nosignal(
+        _ctx(source={VaSource.NOSIGNAL}, mode=VaMode.RESET_TO_NA), vr
+    )
+    assert result.no_signal_frames == "n/a"
+
+
+def test_run_ext_nosignal_reset_to_na_already_na():
+    from reprostim.qr.video_audit import run_ext_nosignal
+
+    ctx = _ctx(source={VaSource.NOSIGNAL}, mode=VaMode.RESET_TO_NA)
+    run_ext_nosignal(ctx, _rec(no_signal_frames="n/a"))
+    assert ctx.c_nosignal == 0
+
+
+def test_run_ext_nosignal_rerun_for_na_skips_non_na():
+    from reprostim.qr.video_audit import run_ext_nosignal
+
+    vr = _rec(no_signal_frames="3.0")
+    result = run_ext_nosignal(
+        _ctx(source={VaSource.NOSIGNAL}, mode=VaMode.RERUN_FOR_NA), vr
+    )
+    assert result.no_signal_frames == "3.0"
+
+
+# ===========================================================================
+# run_ext_qr — early-exit paths
+# ===========================================================================
+
+
+def test_run_ext_qr_wrong_source():
+    from reprostim.qr.video_audit import run_ext_qr
+
+    vr = _rec()
+    assert run_ext_qr(_ctx(source={VaSource.NOSIGNAL}), vr) is vr
+
+
+def test_run_ext_qr_reset_to_na_resets_value():
+    from reprostim.qr.video_audit import run_ext_qr
+
+    vr = _rec(qr_records_number="10")
+    result = run_ext_qr(_ctx(source={VaSource.QR}, mode=VaMode.RESET_TO_NA), vr)
+    assert result.qr_records_number == "n/a"
+
+
+def test_run_ext_qr_reset_to_na_already_na():
+    from reprostim.qr.video_audit import run_ext_qr
+
+    ctx = _ctx(source={VaSource.QR}, mode=VaMode.RESET_TO_NA)
+    run_ext_qr(ctx, _rec(qr_records_number="n/a"))
+    assert ctx.c_qr == 0
+
+
+def test_run_ext_qr_rerun_for_na_skips_non_na():
+    from reprostim.qr.video_audit import run_ext_qr
+
+    vr = _rec(qr_records_number="5")
+    result = run_ext_qr(_ctx(source={VaSource.QR}, mode=VaMode.RERUN_FOR_NA), vr)
+    assert result.qr_records_number == "5"
+
+
+# ===========================================================================
+# do_main
+# ===========================================================================
+
+
+def test_do_main_invalid_path(tmp_path):
+    from reprostim.qr.video_audit import do_main
+
+    with patch.dict(os.environ, _ENV):
+        assert do_main([str(tmp_path / "missing")], str(tmp_path / "out.tsv")) == 1
+
+
+def test_do_main_incremental_creates_tsv(tmp_path):
+    from reprostim.qr.video_audit import do_main
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    tsv = str(tmp_path / "videos.tsv")
+    mock_rec = _rec(name="test.mkv", path=str(mkv))
+    with patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.check_ffprobe", return_value=True
+    ), patch("reprostim.qr.video_audit.do_audit", return_value=iter([mock_rec])):
+        assert do_main([str(tmp_path)], tsv) == 0
+    assert os.path.exists(tsv)
+
+
+def test_do_main_full_mode(tmp_path):
+    from reprostim.qr.video_audit import do_main
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    tsv = str(tmp_path / "videos.tsv")
+    mock_rec = _rec(name="test.mkv", path=str(mkv))
+    with patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.check_ffprobe", return_value=True
+    ), patch("reprostim.qr.video_audit.do_audit", return_value=iter([mock_rec])):
+        assert do_main([str(tmp_path)], tsv, mode=VaMode.FULL) == 0
+
+
+def test_do_main_rerun_for_na_calls_do_ext(tmp_path):
+    from reprostim.qr.video_audit import do_main
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    tsv = str(tmp_path / "videos.tsv")
+    _save_tsv([_rec(name="test.mkv", path=str(mkv))], tsv)
+    mock_rec = _rec(name="test.mkv", path=str(mkv))
+    with patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.check_ffprobe", return_value=True
+    ), patch(
+        "reprostim.qr.video_audit.do_ext", return_value=iter([mock_rec])
+    ) as mock_ext:
+        assert do_main([str(tmp_path)], tsv, mode=VaMode.RERUN_FOR_NA) == 0
+    mock_ext.assert_called_once()
+
+
+def test_do_main_nosignal_opts_shlex_parsed(tmp_path):
+    from reprostim.qr.video_audit import do_main
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    tsv = str(tmp_path / "videos.tsv")
+    captured = {}
+
+    def _capture(ctx, paths):
+        captured["nosignal_opts"] = ctx.nosignal_opts
+        return iter([])
+
+    with patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.check_ffprobe", return_value=True
+    ), patch("reprostim.qr.video_audit.do_audit", side_effect=_capture):
+        do_main([str(tmp_path)], tsv, nosignal_opts="--number-of-checks 50")
+    assert captured["nosignal_opts"] == ["--number-of-checks", "50"]
+
+
+# ===========================================================================
+# get_file_video_audit
+# ===========================================================================
+
+
+def test_get_file_video_audit_tsv_hit(tmp_path):
+    from reprostim.qr.video_audit import _tsv_cache, get_file_video_audit
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    tsv = str(tmp_path / "videos.tsv")
+    _save_tsv([_rec(name="test.mkv", path=str(mkv))], tsv)
+    _tsv_cache.pop(tsv, None)
+    result = get_file_video_audit(str(mkv), path_tsv=tsv, use_lock=False)
+    assert result is not None and result.name == "test.mkv"
+
+
+def test_get_file_video_audit_tsv_miss_fallback(tmp_path):
+    from reprostim.qr.video_audit import _tsv_cache, get_file_video_audit
+
+    mkv = tmp_path / "test.mkv"
+    mkv.touch()
+    tsv = str(tmp_path / "videos.tsv")
+    _save_tsv([_rec(name="other.mkv", path="/data/other.mkv")], tsv)
+    _tsv_cache.pop(tsv, None)
+    fallback = _rec(name="test.mkv", path=str(mkv))
+    with patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.do_audit_file", return_value=iter([fallback])
+    ):
+        result = get_file_video_audit(str(mkv), path_tsv=tsv, use_lock=False)
+    assert result is not None and result.name == "test.mkv"


### PR DESCRIPTION

Extend `video-audit` with custom opts for external tools like `nosignal` and `qr-parse`. To use the latest performance changes in `qr-parse` we need in non-standard opts to be specified there on `typhon`.

**Tasks:**
- [x]  Implement `--nosignal-opts` option.
- [x]  Implement `--qr-opts` option.
- [x] Implement `--config` option and provide `examples/video-audit/config.yaml` example.
- [x] Provide unit tests for `video-audit` and make sure code coverage 80%+ (now its 93%+).
- [x] Fix bug in `video-audit` (_TypeError: expected str, bytes or os.PathLike object, not bool_) 
- [x] Create new release `v0.7.30` and deploy it to `typhon` (after PR merge):
 - #241.
- [x] Fix `code/reprostim-process-na-qr-cron` and update it to use custom config, which would be pyzbar+ scale=0.5 + 5 qr workers. Test it with videos recorded in 2026 (after PR merge).

