### PR TITLE
Ensure saved `videos.tsv` uses LF-only line endings

### DIFF
--- a/.ai/task-video-audit.md
+++ b/.ai/task-video-audit.md
@@ -165,6 +165,9 @@ Test file location: `tests/qr/test_video_audit.py`
 
 #### TSV I/O
 - [x] `_save_tsv` / `_load_tsv` round-trip with temp file
+- [x] `_save_tsv` writes LF-only line endings (no CRLF / `^M`) on all platforms
+- [x] `_load_tsv` reads file with LF line endings correctly
+- [x] `_load_tsv` reads file with CRLF line endings correctly (no `\r` in field values)
 - [x] `_get_tsv_records` — with lock (default)
 - [x] `_get_tsv_records` — cached=True returns cached list on second call
 - [x] `_get_tsv_records` — use_lock=False dirty-read

--- a/src/reprostim/qr/video_audit.py
+++ b/src/reprostim/qr/video_audit.py
@@ -464,7 +464,9 @@ def get_audio_info_ffprobe(path: str) -> AudioInfo:
 def _save_tsv(records: List[VaRecord], path_out: str):
     fields = list(VaRecord.model_fields.keys())
     with open(path_out, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=fields, delimiter="\t")
+        writer = csv.DictWriter(
+            f, fieldnames=fields, delimiter="\t", lineterminator="\n"
+        )
         writer.writeheader()
         for r in records:
             writer.writerow(r.model_dump())

--- a/tests/qr/test_video_audit.py
+++ b/tests/qr/test_video_audit.py
@@ -554,6 +554,51 @@ def test_save_load_tsv_roundtrip(tmp_path):
     assert [r.name for r in loaded] == ["a.mkv", "b.mkv"]
 
 
+def test_save_tsv_uses_lf_line_endings(tmp_path):
+    """_save_tsv must write Unix LF-only line endings (no CRLF / ^M)."""
+    path = str(tmp_path / "videos.tsv")
+    _save_tsv([_rec(name="a.mkv"), _rec(name="b.mkv")], path)
+    raw = open(path, "rb").read()
+    assert b"\r\n" not in raw, "TSV file must not contain CRLF (^M) line endings"
+    assert b"\n" in raw
+
+
+def test_load_tsv_reads_lf_file(tmp_path):
+    """_load_tsv correctly reads a file with Unix LF line endings."""
+    path = str(tmp_path / "videos.tsv")
+    _save_tsv([_rec(name="lf.mkv")], path)
+    loaded = _load_tsv(path)
+    assert len(loaded) == 1
+    assert loaded[0].name == "lf.mkv"
+
+
+def test_load_tsv_reads_crlf_file(tmp_path):
+    """_load_tsv correctly reads a file with Windows CRLF line endings.
+
+    A TSV produced by an older version of the code (or on Windows) may have
+    CRLF terminators.  _load_tsv must parse it without embedding \\r in any
+    field value.
+    """
+    import csv
+
+    path = str(tmp_path / "videos.tsv")
+    rec = _rec(name="crlf.mkv")
+    fields = list(VaRecord.model_fields.keys())
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=fields, delimiter="\t", lineterminator="\r\n"
+        )
+        writer.writeheader()
+        writer.writerow(rec.model_dump())
+
+    loaded = _load_tsv(path)
+    assert len(loaded) == 1
+    assert loaded[0].name == "crlf.mkv"
+    for field in fields:
+        value = getattr(loaded[0], field)
+        assert "\r" not in str(value), f"Field '{field}' must not contain \\r"
+
+
 def test_get_tsv_records_with_lock(tmp_path):
     from reprostim.qr.video_audit import _get_tsv_records, _tsv_cache
 

--- a/tests/qr/test_video_audit.py
+++ b/tests/qr/test_video_audit.py
@@ -558,7 +558,7 @@ def test_save_tsv_uses_lf_line_endings(tmp_path):
     """_save_tsv must write Unix LF-only line endings (no CRLF / ^M)."""
     path = str(tmp_path / "videos.tsv")
     _save_tsv([_rec(name="a.mkv"), _rec(name="b.mkv")], path)
-    raw = open(path, "rb").read()
+    raw = (tmp_path / "videos.tsv").read_bytes()
     assert b"\r\n" not in raw, "TSV file must not contain CRLF (^M) line endings"
     assert b"\n" in raw
 


### PR DESCRIPTION
Somehow `video-audit` produces `videos.tsv` file with RFC 4180 `\r\n` line terminator (^M) , but we need in explicit Unix style with `\n`:

- [x] Fix line terminator to be `\n`
- [x] Provide unit tests for reading/writing and mixed style
- [x] Release `v0.7.31` and deploy on typhon
 