### PR TITLE
Keep `bids-inject` sidecar JSON format in sync with BIDS BEP044/BEP047 WiP spec

### DIFF
--- a/.ai/spec-bids-inject.md
+++ b/.ai/spec-bids-inject.md
@@ -587,6 +587,23 @@ wrappers around `dt_convert`.
 
 ---
 
+## ScanMetadata Model
+
+`ScanMetadata` holds fields extracted from the BIDS JSON sidecar (`*_bold.json` etc.).
+Fields promoted to typed attributes (excluded from `extra`):
+
+| Field                    | Type              | Description                                              |
+|--------------------------|-------------------|----------------------------------------------------------|
+| `TaskName`               | `str \| None`     | Task name from the BIDS sidecar (e.g. `"rest"`)          |
+| `FrameAcquisitionDuration` | `float \| None` | Frame acquisition duration in ms (DICOM tag)             |
+| `AcquisitionTime`        | `list[str] \| None` | Per-volume acquisition times (from `time.samples`)     |
+| `RepetitionTime`         | `float \| None`   | TR in seconds                                            |
+| `NumberOfVolumes`        | `int \| None`     | Number of volumes (from NIfTI header or JSON sidecar)    |
+
+All other keys are stored verbatim in `extra`.
+
+---
+
 ## Duration Computation
 
 Priority order for determining scan duration from BIDS JSON sidecars:

--- a/.ai/spec-split-video.md
+++ b/.ai/spec-split-video.md
@@ -57,17 +57,23 @@ to the sidecar file.
 
 **`_to_bids_model(sr)` mapping:**
 
-| `SplitResult` field   | BIDS field            | Notes                                |
-|-----------------------|-----------------------|--------------------------------------|
-| `duration`            | `RecordingDuration`   | float seconds                        |
-| `video_frame_rate`    | `FrameRate`           | float Hz                             |
-| `video_width`         | `Width`               | int pixels (parsed from string)      |
-| `video_height`        | `Height`              | int pixels (parsed from string)      |
-| `audio_codec`         | `AudioCodec`          | FFmpeg codec name string             |
-| `audio_sample_rate`   | `AudioSampleRate`     | float Hz (parsed from string)        |
-| `audio_channel_count` | `AudioChannelCount`   | int (parsed from string)             |
+| `SplitResult` field   | BIDS field            | Notes                                                      |
+|-----------------------|-----------------------|------------------------------------------------------------|
+| `duration`            | `RecordingDuration`   | float seconds                                              |
+| `video_frame_rate`    | `FrameRate`           | float Hz                                                   |
+| `video_width`         | `Width`               | int pixels (parsed from string)                            |
+| `video_height`        | `Height`              | int pixels (parsed from string)                            |
+| `video_codec`         | `VideoCodec`          | FFmpeg codec name; set to `"h264"` when resolution present |
+| `audio_codec`         | `AudioCodec`          | FFmpeg codec name string                                   |
+| `audio_sample_rate`   | `AudioSampleRate`     | float Hz (parsed from string)                              |
+| `audio_channel_count` | `AudioChannelCount`   | int (parsed from string)                                   |
 
 Fields with value `"n/a"` or `None` are omitted from the BIDS output.
+
+**`video_codec` inference:** `SplitResult.video_codec` is set to `"h264"` whenever a valid
+video resolution is detected, reflecting that reprostim-videocapture encodes with
+`-c:v libx264`. When no video stream is present (`resolution` is `"n/a"`), it remains `"n/a"`
+and `VideoCodec` is omitted from the BIDS sidecar.
 
 **Example BIDS sidecar JSON:**
 ```json
@@ -76,6 +82,7 @@ Fields with value `"n/a"` or `None` are omitted from the BIDS output.
   "FrameRate": 30.0,
   "Width": 1920,
   "Height": 1080,
+  "VideoCodec": "h264",
   "AudioCodec": "aac",
   "AudioSampleRate": 48000.0,
   "AudioChannelCount": 2

--- a/.ai/spec-split-video.md
+++ b/.ai/spec-split-video.md
@@ -45,6 +45,62 @@ option `--buffer-policy=strict|flexible` so if strict, would error out if buffer
 
 ## Enhancements
 
+### BIDS Sidecar Format (`--sidecar-format`) (Implemented)
+
+Added `--sidecar-format` option and `SidecarFormat` enum to control the JSON schema written
+to the sidecar file.
+
+**Enum values:**
+- `bids` (default): Output uses BEP044/BEP047 field names as defined in
+  [bids-standard/bids-specification PR #2367](https://github.com/bids-standard/bids-specification/pull/2367).
+- `raw`: Output is the raw `SplitResult` model dump (previous behaviour, all `orig_*` fields included).
+
+**`_to_bids_model(sr)` mapping:**
+
+| `SplitResult` field   | BIDS field            | Notes                                |
+|-----------------------|-----------------------|--------------------------------------|
+| `duration`            | `RecordingDuration`   | float seconds                        |
+| `video_frame_rate`    | `FrameRate`           | float Hz                             |
+| `video_width`         | `Width`               | int pixels (parsed from string)      |
+| `video_height`        | `Height`              | int pixels (parsed from string)      |
+| `audio_codec`         | `AudioCodec`          | FFmpeg codec name string             |
+| `audio_sample_rate`   | `AudioSampleRate`     | float Hz (parsed from string)        |
+| `audio_channel_count` | `AudioChannelCount`   | int (parsed from string)             |
+
+Fields with value `"n/a"` or `None` are omitted from the BIDS output.
+
+**Example BIDS sidecar JSON:**
+```json
+{
+  "RecordingDuration": 180.0,
+  "FrameRate": 30.0,
+  "Width": 1920,
+  "Height": 1080,
+  "AudioCodec": "aac",
+  "AudioSampleRate": 48000.0,
+  "AudioChannelCount": 2
+}
+```
+
+**`do_main` / `_do_main_specs` signature change:**
+- Both accept `sidecar_format: str | None = None`; `None` resolves to `"bids"` at call time.
+- `_do_main_specs` converts the string to `SidecarFormat` enum analogously to how
+  `buffer_policy` is converted to `BufferPolicy`.
+
+**`bids_inject` behaviour:**
+- Always passes `sidecar_format="bids"` — the BIDS format is hardcoded, no CLI option exposed.
+
+**Usage:**
+```shell
+# BIDS format (default)
+reprostim split-video --sidecar-json auto --sidecar-format bids -i input.mkv -o output.mkv --spec 17:30:00/PT3M
+
+# Raw legacy format
+reprostim split-video --sidecar-json auto --sidecar-format raw -i input.mkv -o output.mkv --spec 17:30:00/PT3M
+```
+
+
+
 ### Buffer Policy (Implemented)
 
 Added `--buffer-policy` option with two modes:

--- a/.ai/spec-split-video.md
+++ b/.ai/spec-split-video.md
@@ -66,6 +66,7 @@ to the sidecar file.
 | `video_codec`         | `VideoCodec`          | FFmpeg codec name; set to `"h264"` when resolution present |
 | *(internal)*          | `VideoCodecRFC6381`   | Always `"n/a"` when `VideoCodec` present; placeholder until ffprobe integration |
 | `audio_codec`         | `AudioCodec`          | FFmpeg codec name string                                   |
+| *(internal)*          | `AudioCodecRFC6381`   | Always `"n/a"` when `AudioCodec` present; placeholder until ffprobe integration |
 | `audio_sample_rate`   | `AudioSampleRate`     | float Hz (parsed from string)                              |
 | `audio_channel_count` | `AudioChannelCount`   | int (parsed from string)                                   |
 
@@ -76,21 +77,24 @@ video resolution is detected, reflecting that reprostim-videocapture encodes wit
 `-c:v libx264`. When no video stream is present (`resolution` is `"n/a"`), it remains `"n/a"`
 and `VideoCodec` is omitted from the BIDS sidecar.
 
-**`VideoCodecRFC6381`:** Emitted alongside `VideoCodec` as `"n/a"` — a placeholder indicating
-the RFC 6381 codec string (e.g. `avc1.640028` for H.264 High Profile Level 4.0) is not yet
-resolved. Exact value requires `ffprobe` to read the encoded profile/level from the output
-file. This field is set purely inside `_to_bids_model`; no corresponding field in `SplitResult`.
-A future enhancement can populate it via ffprobe after the split.
+**`VideoCodecRFC6381` / `AudioCodecRFC6381`:** Each is emitted alongside its FFmpeg-name
+counterpart as `"n/a"` — a placeholder indicating the RFC 6381 codec string is not yet
+resolved. Examples: `avc1.640028` (H.264 High Profile Level 4.0), `mp4a.40.2` (AAC-LC).
+Exact values require `ffprobe` to read the encoded profile/level from the output file.
+Both fields are set purely inside `_to_bids_model`; no corresponding fields in `SplitResult`.
+A future enhancement can populate them via ffprobe after the split.
 
 **Example BIDS sidecar JSON:**
 ```json
 {
   "RecordingDuration": 180.0,
+  "VideoCodec": "h264",
+  "VideoCodecRFC6381": "n/a",
   "FrameRate": 30.0,
   "Width": 1920,
   "Height": 1080,
-  "VideoCodec": "h264",
   "AudioCodec": "aac",
+  "AudioCodecRFC6381": "n/a",
   "AudioSampleRate": 48000.0,
   "AudioChannelCount": 2
 }

--- a/.ai/spec-split-video.md
+++ b/.ai/spec-split-video.md
@@ -64,6 +64,7 @@ to the sidecar file.
 | `video_width`         | `Width`               | int pixels (parsed from string)                            |
 | `video_height`        | `Height`              | int pixels (parsed from string)                            |
 | `video_codec`         | `VideoCodec`          | FFmpeg codec name; set to `"h264"` when resolution present |
+| *(internal)*          | `VideoCodecRFC6381`   | Always `"n/a"` when `VideoCodec` present; placeholder until ffprobe integration |
 | `audio_codec`         | `AudioCodec`          | FFmpeg codec name string                                   |
 | `audio_sample_rate`   | `AudioSampleRate`     | float Hz (parsed from string)                              |
 | `audio_channel_count` | `AudioChannelCount`   | int (parsed from string)                                   |
@@ -74,6 +75,12 @@ Fields with value `"n/a"` or `None` are omitted from the BIDS output.
 video resolution is detected, reflecting that reprostim-videocapture encodes with
 `-c:v libx264`. When no video stream is present (`resolution` is `"n/a"`), it remains `"n/a"`
 and `VideoCodec` is omitted from the BIDS sidecar.
+
+**`VideoCodecRFC6381`:** Emitted alongside `VideoCodec` as `"n/a"` — a placeholder indicating
+the RFC 6381 codec string (e.g. `avc1.640028` for H.264 High Profile Level 4.0) is not yet
+resolved. Exact value requires `ffprobe` to read the encoded profile/level from the output
+file. This field is set purely inside `_to_bids_model`; no corresponding field in `SplitResult`.
+A future enhancement can populate it via ffprobe after the split.
 
 **Example BIDS sidecar JSON:**
 ```json

--- a/.ai/spec-split-video.md
+++ b/.ai/spec-split-video.md
@@ -57,18 +57,21 @@ to the sidecar file.
 
 **`_to_bids_model(sr)` mapping:**
 
-| `SplitResult` field   | BIDS field            | Notes                                                      |
-|-----------------------|-----------------------|------------------------------------------------------------|
-| `duration`            | `RecordingDuration`   | float seconds                                              |
-| `video_frame_rate`    | `FrameRate`           | float Hz                                                   |
-| `video_width`         | `Width`               | int pixels (parsed from string)                            |
-| `video_height`        | `Height`              | int pixels (parsed from string)                            |
-| `video_codec`         | `VideoCodec`          | FFmpeg codec name; set to `"h264"` when resolution present |
-| *(internal)*          | `VideoCodecRFC6381`   | Always `"n/a"` when `VideoCodec` present; placeholder until ffprobe integration |
-| `audio_codec`         | `AudioCodec`          | FFmpeg codec name string                                   |
-| *(internal)*          | `AudioCodecRFC6381`   | Always `"n/a"` when `AudioCodec` present; placeholder until ffprobe integration |
-| `audio_sample_rate`   | `AudioSampleRate`     | float Hz (parsed from string)                              |
-| `audio_channel_count` | `AudioChannelCount`   | int (parsed from string)                                   |
+| `SplitResult` field          | BIDS field            | Notes                                                      |
+|------------------------------|-----------------------|------------------------------------------------------------|
+| `orig_device`                | `Device`              | Capture device name; omitted when `"n/a"`                  |
+| `orig_device_serial_number`  | `DeviceSerialNumber`  | Capture device serial number; omitted when `"n/a"`         |
+| `duration`                   | `RecordingDuration`   | float seconds                                              |
+| `video_codec`                | `VideoCodec`          | FFmpeg codec name; set to `"h264"` when resolution present |
+| *(internal)*                 | `VideoCodecRFC6381`   | Always `"n/a"` when `VideoCodec` present; placeholder until ffprobe integration |
+| `video_frame_rate`           | `FrameRate`           | float Hz                                                   |
+| `video_width`                | `Width`               | int pixels (parsed from string)                            |
+| `video_height`               | `Height`              | int pixels (parsed from string)                            |
+| `audio_codec`                | `AudioCodec`          | FFmpeg codec name string                                   |
+| *(internal)*                 | `AudioCodecRFC6381`   | Always `"n/a"` when `AudioCodec` present; placeholder until ffprobe integration |
+| `audio_sample_rate`          | `AudioSampleRate`     | float Hz (parsed from string)                              |
+| `audio_bit_depth`            | `AudioBitDepth`       | int bits (parsed from string, e.g. `"16"` → `16`)         |
+| `audio_channel_count`        | `AudioChannelCount`   | int (parsed from string)                                   |
 
 Fields with value `"n/a"` or `None` are omitted from the BIDS output.
 
@@ -87,6 +90,8 @@ A future enhancement can populate them via ffprobe after the split.
 **Example BIDS sidecar JSON:**
 ```json
 {
+  "Device": "Magewell USB Capture HDMI 4K Plus",
+  "DeviceSerialNumber": "D321220101234",
   "RecordingDuration": 180.0,
   "VideoCodec": "h264",
   "VideoCodecRFC6381": "n/a",
@@ -96,6 +101,7 @@ A future enhancement can populate them via ffprobe after the split.
   "AudioCodec": "aac",
   "AudioCodecRFC6381": "n/a",
   "AudioSampleRate": 48000.0,
+  "AudioBitDepth": 16,
   "AudioChannelCount": 2
 }
 ```

--- a/.ai/spec-split-video.md
+++ b/.ai/spec-split-video.md
@@ -73,7 +73,7 @@ Currently the only recognised key is `TaskName`; when present it is written as t
 | `sidecar_metadata["TaskName"]` | `TaskName`          | First field; omitted when not in `sidecar_metadata`        |
 | `orig_device`                | `Device`              | Capture device name; omitted when `"n/a"`                  |
 | `orig_device_serial_number`  | `DeviceSerialNumber`  | Capture device serial number; omitted when `"n/a"`         |
-| `duration`                   | `RecordingDuration`   | float seconds                                              |
+| `buffer_duration`            | `RecordingDuration`   | float seconds — total file duration including buffers before and after |
 | `video_codec`                | `VideoCodec`          | FFmpeg codec name; set to `"h264"` when resolution present |
 | *(internal)*                 | `VideoCodecRFC6381`   | Always `"n/a"` when `VideoCodec` present; placeholder until ffprobe integration |
 | `video_frame_rate`           | `FrameRate`           | float Hz                                                   |
@@ -105,7 +105,7 @@ A future enhancement can populate them via ffprobe after the split.
   "TaskName": "rest",
   "Device": "Magewell USB Capture HDMI 4K Plus",
   "DeviceSerialNumber": "D321220101234",
-  "RecordingDuration": 180.0,
+  "RecordingDuration": 190.0,
   "VideoCodec": "h264",
   "VideoCodecRFC6381": "n/a",
   "FrameRate": 30.0,

--- a/.ai/spec-split-video.md
+++ b/.ai/spec-split-video.md
@@ -55,10 +55,22 @@ to the sidecar file.
   [bids-standard/bids-specification PR #2367](https://github.com/bids-standard/bids-specification/pull/2367).
 - `raw`: Output is the raw `SplitResult` model dump (previous behaviour, all `orig_*` fields included).
 
-**`_to_bids_model(sr)` mapping:**
+**`_to_bids_model(sr, sidecar_metadata)` signature:**
 
-| `SplitResult` field          | BIDS field            | Notes                                                      |
+```python
+def _to_bids_model(sr: SplitResult, sidecar_metadata: dict | None = None) -> dict
+```
+
+The optional `sidecar_metadata` dict allows callers to inject extra BIDS fields.
+Currently the only recognised key is `TaskName`; when present it is written as the
+**first** field in the output dict (before `Device`/`DeviceSerialNumber`).
+`bids_inject` populates this from `ScanMetadata.TaskName` at call time.
+
+**`_to_bids_model` field mapping (in output order):**
+
+| Source                       | BIDS field            | Notes                                                      |
 |------------------------------|-----------------------|------------------------------------------------------------|
+| `sidecar_metadata["TaskName"]` | `TaskName`          | First field; omitted when not in `sidecar_metadata`        |
 | `orig_device`                | `Device`              | Capture device name; omitted when `"n/a"`                  |
 | `orig_device_serial_number`  | `DeviceSerialNumber`  | Capture device serial number; omitted when `"n/a"`         |
 | `duration`                   | `RecordingDuration`   | float seconds                                              |
@@ -87,9 +99,10 @@ Exact values require `ffprobe` to read the encoded profile/level from the output
 Both fields are set purely inside `_to_bids_model`; no corresponding fields in `SplitResult`.
 A future enhancement can populate them via ffprobe after the split.
 
-**Example BIDS sidecar JSON:**
+**Example BIDS sidecar JSON (with TaskName from bids_inject):**
 ```json
 {
+  "TaskName": "rest",
   "Device": "Magewell USB Capture HDMI 4K Plus",
   "DeviceSerialNumber": "D321220101234",
   "RecordingDuration": 180.0,
@@ -106,13 +119,16 @@ A future enhancement can populate them via ffprobe after the split.
 }
 ```
 
-**`do_main` / `_do_main_specs` signature change:**
-- Both accept `sidecar_format: str | None = None`; `None` resolves to `"bids"` at call time.
+**`do_main` / `_do_main_specs` / `_write_sidecar` signature:**
+- All accept `sidecar_format: str | None = None`; `None` resolves to `"bids"` at call time.
+- All accept `sidecar_metadata: dict | None = None`; passed through to `_to_bids_model`.
 - `_do_main_specs` converts the string to `SidecarFormat` enum analogously to how
   `buffer_policy` is converted to `BufferPolicy`.
 
 **`bids_inject` behaviour:**
 - Always passes `sidecar_format="bids"` — the BIDS format is hardcoded, no CLI option exposed.
+- Builds `sidecar_metadata = {"TaskName": record.metadata.TaskName}` when `TaskName` is set,
+  otherwise passes an empty dict `{}`.
 
 **Usage:**
 ```shell

--- a/.ai/task-bids-inject.md
+++ b/.ai/task-bids-inject.md
@@ -111,6 +111,7 @@ Tracks implementation progress against [spec-bids-inject.md](spec-bids-inject.md
 ### B) Sidecar JSON — BEP047:Behavior
 - [x] Write `_recording-reprostim_<suffix>.json` alongside the `.mkv`
 - [x] Include onset, duration, actual buffer values, etc
+- [x] `RecordingDuration` maps from `SplitResult.buffer_duration` (total file duration with buffers)
 - [ ] Confirm field names against BEP044/BEP047 schema
 
 ### C) QR codes file — BIDS events-like `.tsv`

--- a/.ai/task-bids-inject.md
+++ b/.ai/task-bids-inject.md
@@ -78,6 +78,7 @@ Tracks implementation progress against [spec-bids-inject.md](spec-bids-inject.md
 - [x] ReproIn `__dup-XX` suffix preserved in output filename
 - [x] Media suffix determination (`_video` / `_audio` / `_audiovideo`) from `videos.tsv`
 - [x] Delegate to `split-video` Python API (`do_main`)
+- [x] Build `sidecar_metadata` dict from `record.metadata.TaskName` and pass to `do_main`
 
 ### Dry-run mode
 - [x] Skip `split-video` call and file writes when `--dry-run`
@@ -225,6 +226,11 @@ Test file location: `tests/qr/test_bids_inject.py` (mirrors `tests/audio/test_au
 - [x] `always` + existing output → 1 injected, files not pre-removed
 - [x] `error` + existing output → exit 1, 1 error, error detail in verbose output
 - [x] `error` + no existing output → 1 injected (normal path)
+
+### sidecar_metadata propagation tests
+
+- [x] `_call_split_video` passes `sidecar_metadata` with `TaskName` from `record.metadata` to `split-video` `do_main`
+- [x] `_call_split_video` passes empty `sidecar_metadata` when `TaskName` is absent from sidecar JSON
 
 ### CLI tests (Click `CliRunner`)
 

--- a/.ai/task-bids-inject.md
+++ b/.ai/task-bids-inject.md
@@ -46,6 +46,10 @@ Tracks implementation progress against [spec-bids-inject.md](spec-bids-inject.md
 - [ ] Filter: skip non-functional scans (those not starting with `func/`)
 - [ ] Filter: skip single-volume acquisitions (4th NIfTI dimension < 2)
 
+### ScanMetadata model
+- [x] `TaskName` — parsed from BIDS JSON sidecar; `None` when absent; excluded from `extra`
+- [x] `FrameAcquisitionDuration`, `AcquisitionTime`, `RepetitionTime`, `NumberOfVolumes` — existing typed fields
+
 ### Scan duration computation
 - [x] Priority 1: `FrameAcquisitionDuration` (ms → seconds)
 - [x] Priority 2: `AcquisitionTime` array — `(t_last − t_first) + TR`
@@ -176,6 +180,11 @@ Test file location: `tests/qr/test_bids_inject.py` (mirrors `tests/audio/test_au
 - [x] `_calc_media_suffix` — audio only → `_audio`
 - [x] `_calc_media_suffix` — both → `_audiovideo`
 - [x] `_calc_media_suffix` — neither → `None`
+- [x] `ScanMetadata.TaskName` — defaults to `None`
+- [x] `ScanMetadata.TaskName` — stores task name string when set
+- [x] `_parse_scan_metadata` — reads `TaskName` from JSON sidecar when present
+- [x] `_parse_scan_metadata` — `TaskName` is `None` when key absent from sidecar
+- [x] `_parse_scan_metadata` — `TaskName` is NOT stored in `extra` (it is a known key)
 - [x] `_calc_scan_duration_sec` — Priority 1: `FrameAcquisitionDuration` (ms → sec)
 - [x] `_calc_scan_duration_sec` — Priority 2: `AcquisitionTime` array (2+ elements)
 - [x] `_calc_scan_duration_sec` — Priority 2: `AcquisitionTime` with single element → falls through

--- a/.ai/task-split-video.md
+++ b/.ai/task-split-video.md
@@ -142,7 +142,9 @@ Test file location: `tests/qr/test_split_video.py` (mirrors `tests/qr/test_bids_
 - [x] `_to_bids_model` — full mapping: all populated fields produce correct BIDS keys
 - [x] `_to_bids_model` — `n/a` string fields omitted from output
 - [x] `_to_bids_model` — `None` optional fields omitted from output
-- [x] `_to_bids_model` — numeric fields parsed correctly (`Width`/`Height` as int, `AudioSampleRate` as float, `AudioChannelCount` as int)
+- [x] `_to_bids_model` — numeric fields parsed correctly (`Width`/`Height` as int, `AudioSampleRate` as float, `AudioBitDepth` as int, `AudioChannelCount` as int)
+- [x] `_to_bids_model` — `Device` / `DeviceSerialNumber` from `orig_device` / `orig_device_serial_number` (at start of output)
+- [x] `_to_bids_model` — `AudioBitDepth` after `AudioSampleRate`
 - [x] `_to_bids_model` — `VideoCodec` present when `video_codec="h264"` (resolution known)
 - [x] `_to_bids_model` — `VideoCodec` absent when `video_codec="n/a"` (no video stream)
 - [x] `_to_bids_model` — `VideoCodecRFC6381: "n/a"` emitted alongside `VideoCodec` as placeholder (no `SplitResult` field; resolved internally)

--- a/.ai/task-split-video.md
+++ b/.ai/task-split-video.md
@@ -61,6 +61,7 @@ Tracks implementation progress against [spec-split-video.md](spec-split-video.md
 - [x] `_write_sidecar` — serialise `SplitResult` to JSON file (BIDS or raw format)
 - [x] `SidecarFormat` enum — `bids` (default) / `raw`
 - [x] `_to_bids_model` — convert `SplitResult` to BEP044/BEP047 BIDS sidecar dict
+- [x] `SplitResult.video_codec` — new field; set to `"h264"` when resolution present (reprostim uses `-c:v libx264`)
 - [x] `auto` / flag-only → `<output>.split-video.jsonl`
 - [x] Explicit path → use that path (treated as template in multi-spec mode)
 - [x] `none` / not specified → no sidecar created
@@ -83,8 +84,8 @@ Tracks implementation progress against [spec-split-video.md](spec-split-video.md
 - [x] Fields: `buffer_before`, `buffer_after`, `orig_buffer_start`, `orig_buffer_end`,
       `buffer_duration`, `orig_buffer_offset`, `orig_start`, `orig_end`, `duration`,
       `orig_offset`, `video_width`, `video_height`, `video_frame_rate`, `video_size_mb`,
-      `video_rate_mbpm`, `audio_sample_rate`, `audio_bit_depth`, `audio_channel_count`,
-      `audio_codec`, `orig_device`, `orig_device_serial_number`
+      `video_rate_mbpm`, `video_codec`, `audio_sample_rate`, `audio_bit_depth`,
+      `audio_channel_count`, `audio_codec`, `orig_device`, `orig_device_serial_number`
 - [x] No absolute dates stored; times only (ISO 8601 time without date)
 
 ---
@@ -142,6 +143,8 @@ Test file location: `tests/qr/test_split_video.py` (mirrors `tests/qr/test_bids_
 - [x] `_to_bids_model` — `n/a` string fields omitted from output
 - [x] `_to_bids_model` — `None` optional fields omitted from output
 - [x] `_to_bids_model` — numeric fields parsed correctly (`Width`/`Height` as int, `AudioSampleRate` as float, `AudioChannelCount` as int)
+- [x] `_to_bids_model` — `VideoCodec` present when `video_codec="h264"` (resolution known)
+- [x] `_to_bids_model` — `VideoCodec` absent when `video_codec="n/a"` (no video stream)
 
 ### Multi-spec mode
 

--- a/.ai/task-split-video.md
+++ b/.ai/task-split-video.md
@@ -59,8 +59,11 @@ Tracks implementation progress against [spec-split-video.md](spec-split-video.md
 ### Sidecar JSON
 - [x] `_resolve_sidecar_path` — derive sidecar path from output path and `--sidecar-json` value
 - [x] `_write_sidecar` — serialise `SplitResult` to JSON file (BIDS or raw format)
+- [x] `_write_sidecar` — accepts `sidecar_metadata: dict | None`; passed to `_to_bids_model`
 - [x] `SidecarFormat` enum — `bids` (default) / `raw`
 - [x] `_to_bids_model` — convert `SplitResult` to BEP044/BEP047 BIDS sidecar dict
+- [x] `_to_bids_model` — accepts `sidecar_metadata: dict | None = None`
+- [x] `_to_bids_model` — `TaskName` from `sidecar_metadata` written as **first** field when present
 - [x] `SplitResult.video_codec` — new field; set to `"h264"` when resolution present (reprostim uses `-c:v libx264`)
 - [x] `auto` / flag-only → `<output>.split-video.jsonl`
 - [x] Explicit path → use that path (treated as template in multi-spec mode)
@@ -71,6 +74,7 @@ Tracks implementation progress against [spec-split-video.md](spec-split-video.md
 ### Entry point (`do_main`)
 - [x] Dispatch to `_do_main_specs` when `--spec` provided
 - [x] Legacy path: `--start` + (`--duration` or `--end`)
+- [x] `sidecar_metadata: dict | None = None` — forwarded to `_do_main_specs`
 
 ---
 
@@ -149,6 +153,11 @@ Test file location: `tests/qr/test_split_video.py` (mirrors `tests/qr/test_bids_
 - [x] `_to_bids_model` — `VideoCodec` absent when `video_codec="n/a"` (no video stream)
 - [x] `_to_bids_model` — `VideoCodecRFC6381: "n/a"` emitted alongside `VideoCodec` as placeholder (no `SplitResult` field; resolved internally)
 - [x] `_to_bids_model` — `AudioCodecRFC6381: "n/a"` emitted alongside `AudioCodec` as placeholder (no `SplitResult` field; resolved internally)
+- [x] `_to_bids_model` — `TaskName` first field when `sidecar_metadata["TaskName"]` set
+- [x] `_to_bids_model` — `TaskName` absent when `sidecar_metadata` is `None` or empty
+- [x] `_to_bids_model` — `TaskName` precedes `Device` in field order
+- [x] `_write_sidecar` — `sidecar_metadata` threaded through to BIDS output (`TaskName` as first key)
+- [x] `do_main` — `sidecar_metadata` forwarded to `_do_main_specs`
 - [ ] `_to_bids_model` — populate `VideoCodecRFC6381` / `AudioCodecRFC6381` from ffprobe output (future work)
 
 ### Multi-spec mode

--- a/.ai/task-split-video.md
+++ b/.ai/task-split-video.md
@@ -16,6 +16,7 @@ Tracks implementation progress against [spec-split-video.md](spec-split-video.md
 - [x] `--buffer-policy [strict|flexible]` — error or trim when buffers exceed video boundaries
 - [x] `--spec` — compact inline segment spec (`START/DURATION` or `START//END`); repeatable; mutually exclusive with `--start`/`--duration`/`--end`
 - [x] `-j / --sidecar-json` — sidecar JSON output control (`none` / `auto` / explicit path)
+- [x] `--sidecar-format [bids|raw]` — sidecar JSON schema: BIDS field names (default) or raw `SplitResult` dump
 - [x] `-a / --video-audit-file` — path to `videos.tsv` (optional, skips on-the-fly metadata)
 - [x] `--raw` — raw mode: any video file accepted, no filename timestamp required
 - [x] `-k / --lock [yes|no]` — advisory file lock for `videos.tsv`
@@ -57,7 +58,9 @@ Tracks implementation progress against [spec-split-video.md](spec-split-video.md
 
 ### Sidecar JSON
 - [x] `_resolve_sidecar_path` — derive sidecar path from output path and `--sidecar-json` value
-- [x] `_write_sidecar` — serialise `SplitResult` to JSON file
+- [x] `_write_sidecar` — serialise `SplitResult` to JSON file (BIDS or raw format)
+- [x] `SidecarFormat` enum — `bids` (default) / `raw`
+- [x] `_to_bids_model` — convert `SplitResult` to BEP044/BEP047 BIDS sidecar dict
 - [x] `auto` / flag-only → `<output>.split-video.jsonl`
 - [x] Explicit path → use that path (treated as template in multi-spec mode)
 - [x] `none` / not specified → no sidecar created
@@ -130,8 +133,15 @@ Test file location: `tests/qr/test_split_video.py` (mirrors `tests/qr/test_bids_
 - [x] `_resolve_sidecar_path` — `auto` → `<output>.split-video.json`
 - [x] `_resolve_sidecar_path` — explicit path → returned unchanged
 - [x] `_resolve_sidecar_path` — `None` → `None`
-- [x] `_write_sidecar` — all expected fields present; excluded fields absent
-- [x] `_write_sidecar` — no absolute dates in sidecar (times only)
+- [x] `_write_sidecar` — raw format: all expected fields present; excluded fields absent
+- [x] `_write_sidecar` — raw format: no absolute dates in sidecar (times only)
+- [x] `_write_sidecar` — default format is BIDS
+- [x] `_write_sidecar` — BIDS format: correct BIDS field names written
+- [x] `_write_sidecar` — raw format: raw `SplitResult` fields written when `sidecar_format="raw"`
+- [x] `_to_bids_model` — full mapping: all populated fields produce correct BIDS keys
+- [x] `_to_bids_model` — `n/a` string fields omitted from output
+- [x] `_to_bids_model` — `None` optional fields omitted from output
+- [x] `_to_bids_model` — numeric fields parsed correctly (`Width`/`Height` as int, `AudioSampleRate` as float, `AudioChannelCount` as int)
 
 ### Multi-spec mode
 
@@ -158,6 +168,8 @@ Test file location: `tests/qr/test_split_video.py` (mirrors `tests/qr/test_bids_
 - [x] Neither `--spec` nor `--start` provided → error
 - [x] `--lock yes` / `--lock no` → passed to `do_main` correctly
 - [x] `--raw` flag → `raw=True` passed to `do_main`
+- [x] `--sidecar-format bids` → `sidecar_format="bids"` passed to `do_main`
+- [x] `--sidecar-format raw` → `sidecar_format="raw"` passed to `do_main`
 
 ### Coverage targets
 

--- a/.ai/task-split-video.md
+++ b/.ai/task-split-video.md
@@ -146,7 +146,8 @@ Test file location: `tests/qr/test_split_video.py` (mirrors `tests/qr/test_bids_
 - [x] `_to_bids_model` — `VideoCodec` present when `video_codec="h264"` (resolution known)
 - [x] `_to_bids_model` — `VideoCodec` absent when `video_codec="n/a"` (no video stream)
 - [x] `_to_bids_model` — `VideoCodecRFC6381: "n/a"` emitted alongside `VideoCodec` as placeholder (no `SplitResult` field; resolved internally)
-- [ ] `_to_bids_model` — populate `VideoCodecRFC6381` from ffprobe output (future work)
+- [x] `_to_bids_model` — `AudioCodecRFC6381: "n/a"` emitted alongside `AudioCodec` as placeholder (no `SplitResult` field; resolved internally)
+- [ ] `_to_bids_model` — populate `VideoCodecRFC6381` / `AudioCodecRFC6381` from ffprobe output (future work)
 
 ### Multi-spec mode
 

--- a/.ai/task-split-video.md
+++ b/.ai/task-split-video.md
@@ -145,6 +145,8 @@ Test file location: `tests/qr/test_split_video.py` (mirrors `tests/qr/test_bids_
 - [x] `_to_bids_model` — numeric fields parsed correctly (`Width`/`Height` as int, `AudioSampleRate` as float, `AudioChannelCount` as int)
 - [x] `_to_bids_model` — `VideoCodec` present when `video_codec="h264"` (resolution known)
 - [x] `_to_bids_model` — `VideoCodec` absent when `video_codec="n/a"` (no video stream)
+- [x] `_to_bids_model` — `VideoCodecRFC6381: "n/a"` emitted alongside `VideoCodec` as placeholder (no `SplitResult` field; resolved internally)
+- [ ] `_to_bids_model` — populate `VideoCodecRFC6381` from ffprobe output (future work)
 
 ### Multi-spec mode
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist/
 *.pyc
 src/reprostim/_version.py
 /temp/
+uv.lock

--- a/src/reprostim/cli/cmd_split_video.py
+++ b/src/reprostim/cli/cmd_split_video.py
@@ -129,6 +129,15 @@ logger = logging.getLogger(__name__)
     "the lock is held by a different OS user.",
 )
 @click.option(
+    "--sidecar-format",
+    type=click.Choice(["bids", "raw"], case_sensitive=False),
+    default="bids",
+    show_default=True,
+    help="Format for the sidecar JSON file. "
+    "'bids' (default): BEP044/BEP047 field names (RecordingDuration, FrameRate, etc.). "
+    "'raw': raw SplitResult model dump.",
+)
+@click.option(
     "-v",
     "--verbose",
     is_flag=True,
@@ -148,6 +157,7 @@ def split_video(
     input_path: str,
     output: str,
     sidecar_json: str | None,
+    sidecar_format: str | None,
     video_audit_file: str | None,
     raw: bool,
     lock: str,
@@ -191,6 +201,7 @@ def split_video(
     logger.info(f"Buffer after     : {buffer_after}")
     logger.info(f"Buffer policy    : {buffer_policy}")
     logger.info(f"Sidecar JSON     : {sidecar_json}")
+    logger.info(f"Sidecar format   : {sidecar_format}")
     logger.info(f"Video audit file : {video_audit_file}")
     logger.info(f"Raw mode         : {raw}")
     logger.info(f"Lock             : {lock}")
@@ -216,6 +227,7 @@ def split_video(
         buffer_after=buffer_after,
         buffer_policy=buffer_policy,
         sidecar_json=sidecar_path,
+        sidecar_format=sidecar_format,
         video_audit_file=video_audit_file,
         raw=raw,
         verbose=verbose,

--- a/src/reprostim/qr/bids_inject.py
+++ b/src/reprostim/qr/bids_inject.py
@@ -225,6 +225,11 @@ class ScanMetadata(BaseModel):
     3. ``RepetitionTime`` (s) × ``NumberOfVolumes``.
     """
 
+    TaskName: Optional[str] = Field(
+        default=None,
+        description="Name of the task performed during the acquisition "
+        "(BIDS TaskName field).",
+    )
     FrameAcquisitionDuration: Optional[float] = Field(
         default=None,
         description="Total frame acquisition duration in milliseconds (DICOM tag).",
@@ -350,11 +355,13 @@ def _parse_scan_metadata(
     )
 
     known_keys = {
+        "TaskName",
         "FrameAcquisitionDuration",
         "RepetitionTime",
         "NumberOfVolumes",
     }
     return ScanMetadata(
+        TaskName=data.get("TaskName"),
         FrameAcquisitionDuration=data.get("FrameAcquisitionDuration"),
         AcquisitionTime=acq_time_list,
         RepetitionTime=data.get("RepetitionTime"),

--- a/src/reprostim/qr/bids_inject.py
+++ b/src/reprostim/qr/bids_inject.py
@@ -754,6 +754,7 @@ def _call_split_video(
 
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
+    from reprostim.qr.split_video import SidecarFormat
     from reprostim.qr.split_video import do_main as split_video_main
 
     captured_errors: List[str] = []
@@ -773,6 +774,7 @@ def _call_split_video(
         buffer_after=ctx.buffer_after,
         buffer_policy=ctx.buffer_policy,
         sidecar_json=sidecar_path,
+        sidecar_format=SidecarFormat.BIDS,
         video_audit_file=ctx.videos_tsv,
         lock=ctx.lock,
         verbose=ctx.verbose,

--- a/src/reprostim/qr/bids_inject.py
+++ b/src/reprostim/qr/bids_inject.py
@@ -772,6 +772,10 @@ def _call_split_video(
         if ctx.out_func:
             ctx.out_func(msg)
 
+    sidecar_metadata: dict = {}
+    if record.metadata and record.metadata.TaskName:
+        sidecar_metadata["TaskName"] = record.metadata.TaskName
+
     ret = split_video_main(
         input_path=input_path,
         output_path=output_path,
@@ -782,6 +786,7 @@ def _call_split_video(
         buffer_policy=ctx.buffer_policy,
         sidecar_json=sidecar_path,
         sidecar_format=SidecarFormat.BIDS,
+        sidecar_metadata=sidecar_metadata,
         video_audit_file=ctx.videos_tsv,
         lock=ctx.lock,
         verbose=ctx.verbose,

--- a/src/reprostim/qr/split_video.py
+++ b/src/reprostim/qr/split_video.py
@@ -136,6 +136,7 @@ def _to_bids_model(sr: "SplitResult") -> dict:
 
     if sr.video_codec != "n/a":
         result["VideoCodec"] = sr.video_codec
+        result["VideoCodecRFC6381"] = "n/a"
 
     if sr.audio_codec != "n/a":
         result["AudioCodec"] = sr.audio_codec

--- a/src/reprostim/qr/split_video.py
+++ b/src/reprostim/qr/split_video.py
@@ -129,8 +129,8 @@ def _to_bids_model(sr: "SplitResult", sidecar_metadata: dict | None = None) -> d
     if sr.orig_device_serial_number != "n/a":
         result["DeviceSerialNumber"] = sr.orig_device_serial_number
 
-    if sr.duration is not None:
-        result["RecordingDuration"] = sr.duration
+    if sr.buffer_duration is not None:
+        result["RecordingDuration"] = sr.buffer_duration
 
     if sr.video_codec != "n/a":
         result["VideoCodec"] = sr.video_codec

--- a/src/reprostim/qr/split_video.py
+++ b/src/reprostim/qr/split_video.py
@@ -119,6 +119,10 @@ def _to_bids_model(sr: "SplitResult") -> dict:
     if sr.duration is not None:
         result["RecordingDuration"] = sr.duration
 
+    if sr.video_codec != "n/a":
+        result["VideoCodec"] = sr.video_codec
+        result["VideoCodecRFC6381"] = "n/a"
+
     if sr.video_frame_rate is not None:
         result["FrameRate"] = sr.video_frame_rate
 
@@ -134,12 +138,9 @@ def _to_bids_model(sr: "SplitResult") -> dict:
         except (ValueError, TypeError):
             pass
 
-    if sr.video_codec != "n/a":
-        result["VideoCodec"] = sr.video_codec
-        result["VideoCodecRFC6381"] = "n/a"
-
     if sr.audio_codec != "n/a":
         result["AudioCodec"] = sr.audio_codec
+        result["AudioCodecRFC6381"] = "n/a"
 
     if sr.audio_sample_rate != "n/a":
         try:

--- a/src/reprostim/qr/split_video.py
+++ b/src/reprostim/qr/split_video.py
@@ -92,6 +92,7 @@ class SplitResult(BaseModel):
     audio_bit_depth: str = "n/a"  # Audio bit depth (hardcoded to '16')
     audio_channel_count: str = "n/a"  # Number of audio channels (e.g., '2')
     audio_codec: str = "n/a"  # Audio codec name (e.g., 'aac')
+    video_codec: str = "n/a"  # Video codec name (e.g., 'h264')
     # orig_ prefixed fields at the end - describe original video timing
     #  context (BIDS compliance)
     orig_buffer_start: str = "n/a"  # Start time of the buffer in ISO 8601 format
@@ -132,6 +133,9 @@ def _to_bids_model(sr: "SplitResult") -> dict:
             result["Height"] = int(sr.video_height)
         except (ValueError, TypeError):
             pass
+
+    if sr.video_codec != "n/a":
+        result["VideoCodec"] = sr.video_codec
 
     if sr.audio_codec != "n/a":
         result["AudioCodec"] = sr.audio_codec
@@ -647,6 +651,7 @@ def _split_video(sd: SplitData, out_path: str) -> SplitResult:
             else "n/a"
         ),
         video_frame_rate=sd.fps,
+        video_codec="h264" if sd.resolution and sd.resolution != "n/a" else "n/a",
         **_parse_audio_info(sd.audio_sr),
         orig_device=sd.device,
         orig_device_serial_number=sd.device_serial_number,

--- a/src/reprostim/qr/split_video.py
+++ b/src/reprostim/qr/split_video.py
@@ -7,6 +7,7 @@ API to split and audit video files recorded by reprostim-videocapture,
 along with their corresponding log files and QR/audio metadata.
 """
 
+import json
 import logging
 import os
 import subprocess
@@ -31,6 +32,13 @@ class BufferPolicy(str, Enum):
 
     STRICT = "strict"
     FLEXIBLE = "flexible"
+
+
+class SidecarFormat(str, Enum):
+    """Format for sidecar JSON output."""
+
+    RAW = "raw"
+    BIDS = "bids"
 
 
 class VideoSegment(BaseModel):
@@ -94,6 +102,53 @@ class SplitResult(BaseModel):
     orig_offset: Optional[float] = None  # Offset of the split segment in seconds
     orig_device: str = "n/a"  # Video-audio capture device name
     orig_device_serial_number: str = "n/a"  # Video-audio capture device serial number
+
+
+def _to_bids_model(sr: "SplitResult") -> dict:
+    """Convert SplitResult to a BEP044/BEP047 BIDS sidecar dict.
+
+    Maps SplitResult fields to BIDS metadata field names as defined in
+    the common media file definitions (bids-standard/bids-specification PR #2367).
+
+    :param sr: SplitResult to convert
+    :return: Dict with BIDS-compliant metadata field names
+    """
+    result = {}
+
+    if sr.duration is not None:
+        result["RecordingDuration"] = sr.duration
+
+    if sr.video_frame_rate is not None:
+        result["FrameRate"] = sr.video_frame_rate
+
+    if sr.video_width != "n/a":
+        try:
+            result["Width"] = int(sr.video_width)
+        except (ValueError, TypeError):
+            pass
+
+    if sr.video_height != "n/a":
+        try:
+            result["Height"] = int(sr.video_height)
+        except (ValueError, TypeError):
+            pass
+
+    if sr.audio_codec != "n/a":
+        result["AudioCodec"] = sr.audio_codec
+
+    if sr.audio_sample_rate != "n/a":
+        try:
+            result["AudioSampleRate"] = float(sr.audio_sample_rate)
+        except (ValueError, TypeError):
+            pass
+
+    if sr.audio_channel_count != "n/a":
+        try:
+            result["AudioChannelCount"] = int(sr.audio_channel_count)
+        except (ValueError, TypeError):
+            pass
+
+    return result
 
 
 def _parse_audio_info(audio_info: Optional[str]) -> dict:
@@ -638,19 +693,27 @@ def _split_video(sd: SplitData, out_path: str) -> SplitResult:
 
 
 def _write_sidecar(
-    sidecar_path: str, sr: SplitResult, verbose: bool = False, out_func=print
+    sidecar_path: str,
+    sr: SplitResult,
+    sidecar_format: SidecarFormat = SidecarFormat.BIDS,
+    verbose: bool = False,
+    out_func=print,
 ) -> None:
     """Write sidecar JSON file with split result metadata.
 
     :param sidecar_path: Path to write sidecar JSON file
     :param sr: SplitResult to serialize
+    :param sidecar_format: Output format — BIDS (default) or RAW
     :param verbose: Enable verbose output
     :param out_func: Output function for printing messages
     :raises IOError: If the file cannot be written
     """
     logger.info(f"Writing sidecar JSON to: {sidecar_path}")
     with open(sidecar_path, "w") as f:
-        f.write(sr.model_dump_json(indent=2))
+        if sidecar_format == SidecarFormat.BIDS:
+            f.write(json.dumps(_to_bids_model(sr), indent=2))
+        else:
+            f.write(sr.model_dump_json(indent=2))
         f.write("\n")
     logger.debug("Sidecar JSON file written successfully")
     if verbose:
@@ -693,9 +756,10 @@ def _do_main_specs(
     buffer_after: str | None,
     buffer_policy: str,
     sidecar_json: str | None,
-    video_audit_file: str | None,
-    raw: bool,
-    verbose: bool,
+    sidecar_format: str | None = None,
+    video_audit_file: str | None = None,
+    raw: bool = False,
+    verbose: bool = False,
     lock: bool = True,
     out_func=print,
 ) -> int:
@@ -737,6 +801,7 @@ def _do_main_specs(
     buf_before_sec = _parse_interval_sec(buffer_before)
     buf_after_sec = _parse_interval_sec(buffer_after)
     bp = BufferPolicy(buffer_policy.lower())
+    sf = SidecarFormat((sidecar_format or "bids").lower())
 
     for idx, spec_str in enumerate(specs, start=1):
         try:
@@ -807,7 +872,7 @@ def _do_main_specs(
                     sd.sel_seg.end_ts,
                     sd.sel_seg.duration_sec,
                 )
-                _write_sidecar(sidecar_path, sr, verbose, out_func)
+                _write_sidecar(sidecar_path, sr, sf, verbose, out_func)
 
         except Exception as e:
             msg = f"Spec [{idx}] '{spec_str}': {e}"
@@ -829,6 +894,7 @@ def do_main(
     buffer_after: str | None = None,
     buffer_policy: str = "strict",
     sidecar_json: str | None = None,
+    sidecar_format: str = "bids",
     video_audit_file: str | None = None,
     raw: bool = False,
     verbose: bool = False,
@@ -867,6 +933,9 @@ def do_main(
     sidecar_json : str | None
         Path to write sidecar JSON file with split metadata. If None, no sidecar
         file is created.
+    sidecar_format : str
+        Format for the sidecar JSON. 'bids' (default) uses BEP044/BEP047 field
+        names; 'raw' dumps the SplitResult model directly.
     video_audit_file : str | None
         Path to video audit TSV file. If provided, uses this file instead of
         generating video metadata on-the-fly. Passed to get_file_video_audit
@@ -936,6 +1005,7 @@ def do_main(
             buffer_after=buffer_after,
             buffer_policy=buffer_policy,
             sidecar_json=sidecar_json,
+            sidecar_format=sidecar_format,
             video_audit_file=video_audit_file,
             raw=raw,
             verbose=verbose,

--- a/src/reprostim/qr/split_video.py
+++ b/src/reprostim/qr/split_video.py
@@ -105,16 +105,23 @@ class SplitResult(BaseModel):
     orig_device_serial_number: str = "n/a"  # Video-audio capture device serial number
 
 
-def _to_bids_model(sr: "SplitResult") -> dict:
+def _to_bids_model(sr: "SplitResult", sidecar_metadata: dict | None = None) -> dict:
     """Convert SplitResult to a BEP044/BEP047 BIDS sidecar dict.
 
     Maps SplitResult fields to BIDS metadata field names as defined in
     the common media file definitions (bids-standard/bids-specification PR #2367).
 
     :param sr: SplitResult to convert
+    :param sidecar_metadata: Optional dict with extra BIDS fields to inject.
+        Currently supports ``TaskName`` (written as the first field when present).
     :return: Dict with BIDS-compliant metadata field names
     """
     result = {}
+
+    if sidecar_metadata:
+        task_name = sidecar_metadata.get("TaskName")
+        if task_name:
+            result["TaskName"] = task_name
 
     if sr.orig_device != "n/a":
         result["Device"] = sr.orig_device
@@ -715,6 +722,7 @@ def _write_sidecar(
     sidecar_path: str,
     sr: SplitResult,
     sidecar_format: SidecarFormat = SidecarFormat.BIDS,
+    sidecar_metadata: dict | None = None,
     verbose: bool = False,
     out_func=print,
 ) -> None:
@@ -723,6 +731,8 @@ def _write_sidecar(
     :param sidecar_path: Path to write sidecar JSON file
     :param sr: SplitResult to serialize
     :param sidecar_format: Output format — BIDS (default) or RAW
+    :param sidecar_metadata: Optional extra BIDS fields (e.g. ``TaskName``) to
+        inject into the BIDS sidecar.  Ignored in RAW format.
     :param verbose: Enable verbose output
     :param out_func: Output function for printing messages
     :raises IOError: If the file cannot be written
@@ -730,7 +740,7 @@ def _write_sidecar(
     logger.info(f"Writing sidecar JSON to: {sidecar_path}")
     with open(sidecar_path, "w") as f:
         if sidecar_format == SidecarFormat.BIDS:
-            f.write(json.dumps(_to_bids_model(sr), indent=2))
+            f.write(json.dumps(_to_bids_model(sr, sidecar_metadata), indent=2))
         else:
             f.write(sr.model_dump_json(indent=2))
         f.write("\n")
@@ -776,6 +786,7 @@ def _do_main_specs(
     buffer_policy: str,
     sidecar_json: str | None,
     sidecar_format: str | None = None,
+    sidecar_metadata: dict | None = None,
     video_audit_file: str | None = None,
     raw: bool = False,
     verbose: bool = False,
@@ -891,7 +902,9 @@ def _do_main_specs(
                     sd.sel_seg.end_ts,
                     sd.sel_seg.duration_sec,
                 )
-                _write_sidecar(sidecar_path, sr, sf, verbose, out_func)
+                _write_sidecar(
+                    sidecar_path, sr, sf, sidecar_metadata, verbose, out_func
+                )
 
         except Exception as e:
             msg = f"Spec [{idx}] '{spec_str}': {e}"
@@ -914,6 +927,7 @@ def do_main(
     buffer_policy: str = "strict",
     sidecar_json: str | None = None,
     sidecar_format: str = "bids",
+    sidecar_metadata: dict | None = None,
     video_audit_file: str | None = None,
     raw: bool = False,
     verbose: bool = False,
@@ -955,6 +969,9 @@ def do_main(
     sidecar_format : str
         Format for the sidecar JSON. 'bids' (default) uses BEP044/BEP047 field
         names; 'raw' dumps the SplitResult model directly.
+    sidecar_metadata : dict | None
+        Optional dict with extra BIDS fields to inject into the BIDS sidecar
+        (e.g. ``{"TaskName": "rest"}``).  Ignored in RAW format.
     video_audit_file : str | None
         Path to video audit TSV file. If provided, uses this file instead of
         generating video metadata on-the-fly. Passed to get_file_video_audit
@@ -1025,6 +1042,7 @@ def do_main(
             buffer_policy=buffer_policy,
             sidecar_json=sidecar_json,
             sidecar_format=sidecar_format,
+            sidecar_metadata=sidecar_metadata,
             video_audit_file=video_audit_file,
             raw=raw,
             verbose=verbose,

--- a/src/reprostim/qr/split_video.py
+++ b/src/reprostim/qr/split_video.py
@@ -116,6 +116,12 @@ def _to_bids_model(sr: "SplitResult") -> dict:
     """
     result = {}
 
+    if sr.orig_device != "n/a":
+        result["Device"] = sr.orig_device
+
+    if sr.orig_device_serial_number != "n/a":
+        result["DeviceSerialNumber"] = sr.orig_device_serial_number
+
     if sr.duration is not None:
         result["RecordingDuration"] = sr.duration
 
@@ -145,6 +151,12 @@ def _to_bids_model(sr: "SplitResult") -> dict:
     if sr.audio_sample_rate != "n/a":
         try:
             result["AudioSampleRate"] = float(sr.audio_sample_rate)
+        except (ValueError, TypeError):
+            pass
+
+    if sr.audio_bit_depth != "n/a":
+        try:
+            result["AudioBitDepth"] = int(sr.audio_bit_depth)
         except (ValueError, TypeError):
             pass
 

--- a/tests/data/bids_inject/sub-qa/ses-20250814/func/sub-qa_ses-20250814_task-rest_acq-p2_bold.json
+++ b/tests/data/bids_inject/sub-qa/ses-20250814/func/sub-qa_ses-20250814_task-rest_acq-p2_bold.json
@@ -1,1 +1,1 @@
-{"RepetitionTime": 2.0, "NumberOfVolumes": 10}
+{"TaskName": "rest", "RepetitionTime": 2.0, "NumberOfVolumes": 10}

--- a/tests/data/bids_inject/sub-qa/ses-20250814/func/sub-qa_ses-20250814_task-rest_acq-p2_bold__dup-01.json
+++ b/tests/data/bids_inject/sub-qa/ses-20250814/func/sub-qa_ses-20250814_task-rest_acq-p2_bold__dup-01.json
@@ -1,1 +1,1 @@
-{"RepetitionTime": 2.0, "NumberOfVolumes": 10}
+{"TaskName": "rest", "RepetitionTime": 2.0, "NumberOfVolumes": 10}

--- a/tests/qr/test_bids_inject.py
+++ b/tests/qr/test_bids_inject.py
@@ -17,12 +17,14 @@ from reprostim.qr.bids_inject import (
     MediaSuffix,
     ScanMetadata,
     ScanRecord,
+    ScansModel,
     _calc_bids_output_stem,
     _calc_media_suffix,
     _calc_scan_duration_sec,
     _calc_scan_start_end_ts,
     _find_bids_root,
     _is_scans_file,
+    _parse_scan_metadata,
     do_main,
     dt_bids_to_reprostim,
     dt_bids_to_utc,
@@ -475,6 +477,86 @@ def test_calc_scan_duration_sec_priority3_tr_times_volumes():
 def test_calc_scan_duration_sec_no_metadata_returns_none():
     r = ScanRecord(filename="func/test_bold.nii.gz", acq_time="2025-01-15T12:00:00")
     assert _calc_scan_duration_sec(r) is None
+
+
+# ===========================================================================
+# ScanMetadata.TaskName / _load_scan_metadata
+# ===========================================================================
+
+BIDS_FIXTURE = Path(__file__).parent.parent / "data" / "bids_inject"
+_BOLD_JSON = (
+    BIDS_FIXTURE
+    / "sub-qa"
+    / "ses-20250814"
+    / "func"
+    / "sub-qa_ses-20250814_task-rest_acq-p2_bold.json"
+)
+_SCANS_TSV = BIDS_FIXTURE / "sub-qa" / "ses-20250814" / "sub-qa_ses-20250814_scans.tsv"
+
+
+def test_scan_metadata_task_name_defaults_to_none():
+    """ScanMetadata.TaskName is None when not provided."""
+    m = ScanMetadata()
+    assert m.TaskName is None
+
+
+def test_scan_metadata_task_name_set():
+    """ScanMetadata.TaskName stores the task name string."""
+    m = ScanMetadata(TaskName="rest")
+    assert m.TaskName == "rest"
+
+
+def test_load_scan_metadata_task_name_present(tmp_path):
+    """_load_scan_metadata reads TaskName from JSON sidecar."""
+    scans_tsv = tmp_path / "sub-qa_ses-20250814_scans.tsv"
+    scans_tsv.write_text("filename\tacq_time\n")
+    json_sidecar = tmp_path / "func" / "sub-qa_ses-20250814_task-rest_bold.json"
+    json_sidecar.parent.mkdir()
+    json_sidecar.write_text(
+        '{"TaskName": "rest", "RepetitionTime": 2.0, "NumberOfVolumes": 5}'
+    )
+    record = ScanRecord(
+        filename="func/sub-qa_ses-20250814_task-rest_bold.nii.gz",
+        acq_time="2025-01-15T12:00:00",
+    )
+    model = ScansModel(path=str(scans_tsv), records=[record])
+    meta = _parse_scan_metadata(model, record)
+    assert meta is not None
+    assert meta.TaskName == "rest"
+
+
+def test_load_scan_metadata_task_name_absent(tmp_path):
+    """_parse_scan_metadata sets TaskName to None when key absent from sidecar."""
+    scans_tsv = tmp_path / "sub-qa_ses-20250814_scans.tsv"
+    scans_tsv.write_text("filename\tacq_time\n")
+    json_sidecar = tmp_path / "func" / "sub-qa_ses-20250814_task-rest_bold.json"
+    json_sidecar.parent.mkdir()
+    json_sidecar.write_text('{"RepetitionTime": 2.0, "NumberOfVolumes": 5}')
+    record = ScanRecord(
+        filename="func/sub-qa_ses-20250814_task-rest_bold.nii.gz",
+        acq_time="2025-01-15T12:00:00",
+    )
+    model = ScansModel(path=str(scans_tsv), records=[record])
+    meta = _parse_scan_metadata(model, record)
+    assert meta is not None
+    assert meta.TaskName is None
+
+
+def test_load_scan_metadata_task_name_not_in_extra(tmp_path):
+    """TaskName is a known key and must not appear in ScanMetadata.extra."""
+    scans_tsv = tmp_path / "sub-qa_ses-20250814_scans.tsv"
+    scans_tsv.write_text("filename\tacq_time\n")
+    json_sidecar = tmp_path / "func" / "sub-qa_ses-20250814_task-rest_bold.json"
+    json_sidecar.parent.mkdir()
+    json_sidecar.write_text('{"TaskName": "rest", "RepetitionTime": 2.0}')
+    record = ScanRecord(
+        filename="func/sub-qa_ses-20250814_task-rest_bold.nii.gz",
+        acq_time="2025-01-15T12:00:00",
+    )
+    model = ScansModel(path=str(scans_tsv), records=[record])
+    meta = _parse_scan_metadata(model, record)
+    assert meta is not None
+    assert "TaskName" not in meta.extra
 
 
 # ===========================================================================

--- a/tests/qr/test_bids_inject.py
+++ b/tests/qr/test_bids_inject.py
@@ -9,6 +9,7 @@ import shutil
 from datetime import datetime, time, timezone
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import pytest
@@ -960,3 +961,66 @@ def test_overwrite_error_proceeds_when_no_output(tmp_path):
     assert ret == 0
     summary = next(line for line in output if "injected" in line)
     assert "1 injected" in summary
+
+
+# ===========================================================================
+# sidecar_metadata propagation from bids_inject → split_video
+# ===========================================================================
+
+
+def test_call_split_video_passes_task_name_in_sidecar_metadata(tmp_path):
+    """_call_split_video passes sidecar_metadata with TaskName to split-video."""
+    scans_tsv = _copy_bids_fixture(tmp_path)
+    videos_tsv = _write_videos_tsv(tmp_path, _VA_V1)
+
+    captured = {}
+
+    def _fake_split_video_main(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    with patch("reprostim.qr.split_video.do_main", side_effect=_fake_split_video_main):
+        ret, _ = _run(
+            [str(scans_tsv)],
+            videos_tsv,
+            match=_MATCH_TASK_REST,
+            overwrite="skip",
+            dry_run=False,
+        )
+
+    assert ret == 0
+    assert "sidecar_metadata" in captured
+    assert captured["sidecar_metadata"].get("TaskName") == "rest"
+
+
+def test_call_split_video_empty_sidecar_metadata_when_no_task_name(tmp_path):
+    """_call_split_video passes empty sidecar_metadata when TaskName absent."""
+    scans_tsv = _copy_bids_fixture(tmp_path)
+    videos_tsv = _write_videos_tsv(tmp_path, _VA_V2)
+
+    # Overwrite sidecar JSON to remove TaskName
+    sidecar_json = (
+        scans_tsv.parent
+        / "func"
+        / "sub-qa_ses-20250814_task-rest_acq-p2_bold__dup-01.json"
+    )
+    sidecar_json.write_text('{"RepetitionTime": 2.0, "NumberOfVolumes": 10}')
+
+    captured = {}
+
+    def _fake_split_video_main(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    with patch("reprostim.qr.split_video.do_main", side_effect=_fake_split_video_main):
+        ret, _ = _run(
+            [str(scans_tsv)],
+            videos_tsv,
+            match=r"__dup-01",
+            overwrite="skip",
+            dry_run=False,
+        )
+
+    assert ret == 0
+    assert "sidecar_metadata" in captured
+    assert captured["sidecar_metadata"] == {}

--- a/tests/qr/test_split_video.py
+++ b/tests/qr/test_split_video.py
@@ -704,6 +704,38 @@ def test_to_bids_model_no_raw_fields():
         assert key not in data, f"Raw field '{key}' should not appear in BIDS output"
 
 
+def test_to_bids_model_task_name_first_field():
+    """TaskName from sidecar_metadata is output as the first field in BIDS JSON."""
+    sr = _make_split_result()
+    data = _to_bids_model(sr, sidecar_metadata={"TaskName": "rest"})
+    assert data["TaskName"] == "rest"
+    keys = list(data.keys())
+    assert keys[0] == "TaskName", f"TaskName must be the first key, got: {keys}"
+
+
+def test_to_bids_model_task_name_absent_when_not_in_metadata():
+    """TaskName is absent when sidecar_metadata does not contain it."""
+    sr = _make_split_result()
+    data = _to_bids_model(sr, sidecar_metadata={})
+    assert "TaskName" not in data
+
+
+def test_to_bids_model_task_name_absent_when_metadata_is_none():
+    """TaskName is absent when sidecar_metadata is None."""
+    sr = _make_split_result()
+    data = _to_bids_model(sr, sidecar_metadata=None)
+    assert "TaskName" not in data
+
+
+def test_to_bids_model_task_name_first_before_device():
+    """TaskName precedes Device in field order when both are present."""
+    sr = _make_split_result()
+    data = _to_bids_model(sr, sidecar_metadata={"TaskName": "faces"})
+    keys = list(data.keys())
+    assert "TaskName" in keys and "Device" in keys
+    assert keys.index("TaskName") < keys.index("Device")
+
+
 # ===========================================================================
 # _write_sidecar — format variants
 # ===========================================================================
@@ -758,6 +790,26 @@ def test_write_sidecar_raw_format():
         assert "video_frame_rate" in data
         assert "audio_codec" in data
         assert "RecordingDuration" not in data
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_write_sidecar_bids_with_sidecar_metadata():
+    """sidecar_metadata is threaded through to BIDS output (TaskName as first key)."""
+    sr = _make_split_result()
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
+        tmp_path = tmp.name
+    try:
+        _write_sidecar(
+            tmp_path,
+            sr,
+            SidecarFormat.BIDS,
+            sidecar_metadata={"TaskName": "memory"},
+        )
+        with open(tmp_path) as f:
+            data = json.load(f)
+        assert data["TaskName"] == "memory"
+        assert list(data.keys())[0] == "TaskName"
     finally:
         os.unlink(tmp_path)
 
@@ -1304,6 +1356,20 @@ def test_do_main_value_error_from_specs_returns_5():
         )
     assert result == 5
     assert any("ERROR" in m for m in messages)
+
+
+def test_do_main_sidecar_metadata_passed_to_do_main_specs():
+    """do_main forwards sidecar_metadata to _do_main_specs."""
+    meta = {"TaskName": "nback"}
+    with patch("reprostim.qr.split_video._do_main_specs", return_value=0) as mock_dms:
+        do_main(
+            input_path="/fake/video.mkv",
+            output_path="/out/clip.mkv",
+            start_time="2024-02-02T17:30:00",
+            duration="PT3M",
+            sidecar_metadata=meta,
+        )
+    assert mock_dms.call_args.kwargs.get("sidecar_metadata") == meta
 
 
 # ===========================================================================

--- a/tests/qr/test_split_video.py
+++ b/tests/qr/test_split_video.py
@@ -594,7 +594,7 @@ def test_to_bids_model_full_mapping():
 
     assert data["Device"] == "TestDevice"
     assert data["DeviceSerialNumber"] == "SN-12345"
-    assert data["RecordingDuration"] == 180.0
+    assert data["RecordingDuration"] == 190.0
     assert data["VideoCodec"] == "h264"
     assert data["VideoCodecRFC6381"] == "n/a"
     assert data["FrameRate"] == 30.0
@@ -633,7 +633,7 @@ def test_to_bids_model_na_fields_omitted():
     assert "AudioSampleRate" not in data
     assert "AudioBitDepth" not in data
     assert "AudioChannelCount" not in data
-    assert data["RecordingDuration"] == 60.0
+    assert "RecordingDuration" not in data
     assert data["FrameRate"] == 25.0
 
 

--- a/tests/qr/test_split_video.py
+++ b/tests/qr/test_split_video.py
@@ -592,15 +592,18 @@ def test_to_bids_model_full_mapping():
     sr = _make_split_result()
     data = _to_bids_model(sr)
 
+    assert data["Device"] == "TestDevice"
+    assert data["DeviceSerialNumber"] == "SN-12345"
     assert data["RecordingDuration"] == 180.0
+    assert data["VideoCodec"] == "h264"
+    assert data["VideoCodecRFC6381"] == "n/a"
     assert data["FrameRate"] == 30.0
     assert data["Width"] == 1920
     assert data["Height"] == 1080
-    assert data["VideoCodec"] == "h264"
-    assert data["VideoCodecRFC6381"] == "n/a"
     assert data["AudioCodec"] == "aac"
     assert data["AudioCodecRFC6381"] == "n/a"
     assert data["AudioSampleRate"] == 48000.0
+    assert data["AudioBitDepth"] == 16
     assert data["AudioChannelCount"] == 2
 
 
@@ -614,15 +617,21 @@ def test_to_bids_model_na_fields_omitted():
         video_codec="n/a",
         audio_codec="n/a",
         audio_sample_rate="n/a",
+        audio_bit_depth="n/a",
         audio_channel_count="n/a",
+        orig_device="n/a",
+        orig_device_serial_number="n/a",
     )
     data = _to_bids_model(sr)
 
+    assert "Device" not in data
+    assert "DeviceSerialNumber" not in data
     assert "Width" not in data
     assert "Height" not in data
     assert "VideoCodec" not in data
     assert "AudioCodec" not in data
     assert "AudioSampleRate" not in data
+    assert "AudioBitDepth" not in data
     assert "AudioChannelCount" not in data
     assert data["RecordingDuration"] == 60.0
     assert data["FrameRate"] == 25.0
@@ -683,7 +692,10 @@ def test_to_bids_model_no_raw_fields():
         "video_codec",
         "audio_codec",
         "audio_sample_rate",
+        "audio_bit_depth",
         "audio_channel_count",
+        "orig_device",
+        "orig_device_serial_number",
         "orig_start",
         "orig_end",
         "orig_buffer_start",

--- a/tests/qr/test_split_video.py
+++ b/tests/qr/test_split_video.py
@@ -18,6 +18,7 @@ import pytest
 
 from reprostim.qr.split_video import (
     BufferPolicy,
+    SidecarFormat,
     SpecEntry,
     SplitData,
     SplitResult,
@@ -32,6 +33,7 @@ from reprostim.qr.split_video import (
     _parse_ts,
     _resolve_sidecar_path,
     _split_video,
+    _to_bids_model,
     _write_sidecar,
     do_main,
 )
@@ -540,13 +542,13 @@ def _make_split_result() -> SplitResult:
 
 
 def test_write_sidecar_expected_fields_present_excluded_absent():
-    """All expected fields written; excluded fields absent from sidecar."""
+    """All expected raw fields written; excluded fields absent from sidecar."""
     sr = _make_split_result()
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
         tmp_path = tmp.name
 
     try:
-        _write_sidecar(tmp_path, sr)
+        _write_sidecar(tmp_path, sr, SidecarFormat.RAW)
         with open(tmp_path) as f:
             data = json.load(f)
 
@@ -560,13 +562,13 @@ def test_write_sidecar_expected_fields_present_excluded_absent():
 
 
 def test_write_sidecar_no_absolute_dates():
-    """Sidecar JSON contains no absolute date strings (times only)."""
+    """Raw sidecar JSON contains no absolute date strings (times only)."""
     sr = _make_split_result()
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
         tmp_path = tmp.name
 
     try:
-        _write_sidecar(tmp_path, sr)
+        _write_sidecar(tmp_path, sr, SidecarFormat.RAW)
         with open(tmp_path) as f:
             raw = f.read()
 
@@ -575,6 +577,153 @@ def test_write_sidecar_no_absolute_dates():
         assert not date_pattern.search(
             raw
         ), "Sidecar contains absolute date string: " + str(date_pattern.findall(raw))
+    finally:
+        os.unlink(tmp_path)
+
+
+# ===========================================================================
+# _to_bids_model
+# ===========================================================================
+
+
+def test_to_bids_model_full_mapping():
+    """All populated SplitResult fields map to correct BIDS keys."""
+    sr = _make_split_result()
+    data = _to_bids_model(sr)
+
+    assert data["RecordingDuration"] == 180.0
+    assert data["FrameRate"] == 30.0
+    assert data["Width"] == 1920
+    assert data["Height"] == 1080
+    assert data["AudioCodec"] == "aac"
+    assert data["AudioSampleRate"] == 48000.0
+    assert data["AudioChannelCount"] == 2
+
+
+def test_to_bids_model_na_fields_omitted():
+    """Fields with value 'n/a' are omitted from BIDS output."""
+    sr = SplitResult(
+        duration=60.0,
+        video_frame_rate=25.0,
+        video_width="n/a",
+        video_height="n/a",
+        audio_codec="n/a",
+        audio_sample_rate="n/a",
+        audio_channel_count="n/a",
+    )
+    data = _to_bids_model(sr)
+
+    assert "Width" not in data
+    assert "Height" not in data
+    assert "AudioCodec" not in data
+    assert "AudioSampleRate" not in data
+    assert "AudioChannelCount" not in data
+    assert data["RecordingDuration"] == 60.0
+    assert data["FrameRate"] == 25.0
+
+
+def test_to_bids_model_none_values_omitted():
+    """Fields with None value are omitted from BIDS output."""
+    sr = SplitResult(duration=None, video_frame_rate=None)
+    data = _to_bids_model(sr)
+
+    assert "RecordingDuration" not in data
+    assert "FrameRate" not in data
+
+
+def test_to_bids_model_numeric_types():
+    """Width/Height are int, AudioSampleRate is float, AudioChannelCount is int."""
+    sr = SplitResult(
+        video_width="1280",
+        video_height="720",
+        audio_sample_rate="44100",
+        audio_channel_count="1",
+    )
+    data = _to_bids_model(sr)
+
+    assert isinstance(data["Width"], int) and data["Width"] == 1280
+    assert isinstance(data["Height"], int) and data["Height"] == 720
+    assert (
+        isinstance(data["AudioSampleRate"], float)
+        and data["AudioSampleRate"] == 44100.0
+    )
+    assert isinstance(data["AudioChannelCount"], int) and data["AudioChannelCount"] == 1
+
+
+def test_to_bids_model_no_raw_fields():
+    """BIDS output contains no raw SplitResult field names."""
+    sr = _make_split_result()
+    data = _to_bids_model(sr)
+    raw_keys = {
+        "duration",
+        "video_frame_rate",
+        "video_width",
+        "video_height",
+        "audio_codec",
+        "audio_sample_rate",
+        "audio_channel_count",
+        "orig_start",
+        "orig_end",
+        "orig_buffer_start",
+    }
+    for key in raw_keys:
+        assert key not in data, f"Raw field '{key}' should not appear in BIDS output"
+
+
+# ===========================================================================
+# _write_sidecar — format variants
+# ===========================================================================
+
+
+def test_write_sidecar_default_is_bids():
+    """Default _write_sidecar call produces BIDS field names."""
+    sr = _make_split_result()
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
+        tmp_path = tmp.name
+    try:
+        _write_sidecar(tmp_path, sr)
+        with open(tmp_path) as f:
+            data = json.load(f)
+        assert "RecordingDuration" in data
+        assert "FrameRate" in data
+        assert "duration" not in data
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_write_sidecar_bids_format_explicit():
+    """SidecarFormat.BIDS produces BEP044/BEP047 field names."""
+    sr = _make_split_result()
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
+        tmp_path = tmp.name
+    try:
+        _write_sidecar(tmp_path, sr, SidecarFormat.BIDS)
+        with open(tmp_path) as f:
+            data = json.load(f)
+        assert "RecordingDuration" in data
+        assert "Width" in data
+        assert "Height" in data
+        assert "AudioCodec" in data
+        assert "AudioSampleRate" in data
+        assert "AudioChannelCount" in data
+        assert "FrameRate" in data
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_write_sidecar_raw_format():
+    """SidecarFormat.RAW produces raw SplitResult field names."""
+    sr = _make_split_result()
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
+        tmp_path = tmp.name
+    try:
+        _write_sidecar(tmp_path, sr, SidecarFormat.RAW)
+        with open(tmp_path) as f:
+            data = json.load(f)
+        assert "duration" in data
+        assert "video_frame_rate" in data
+        assert "audio_codec" in data
+        assert "RecordingDuration" not in data
     finally:
         os.unlink(tmp_path)
 
@@ -893,6 +1042,46 @@ def test_cli_raw_flag_passed_to_do_main(input_video):
         )
         mock_dm.assert_called_once()
         assert mock_dm.call_args.kwargs["raw"] is True
+
+
+def test_cli_sidecar_format_bids_passed_to_do_main(input_video):
+    """--sidecar-format bids passes sidecar_format='bids' to do_main."""
+    with patch("reprostim.qr.split_video.do_main", return_value=0) as mock_dm:
+        CliRunner().invoke(
+            split_video,
+            [
+                "-i",
+                input_video,
+                "-o",
+                "out.mkv",
+                "--spec",
+                "300/180",
+                "--sidecar-format",
+                "bids",
+            ],
+        )
+        mock_dm.assert_called_once()
+        assert mock_dm.call_args.kwargs["sidecar_format"] == "bids"
+
+
+def test_cli_sidecar_format_raw_passed_to_do_main(input_video):
+    """--sidecar-format raw passes sidecar_format='raw' to do_main."""
+    with patch("reprostim.qr.split_video.do_main", return_value=0) as mock_dm:
+        CliRunner().invoke(
+            split_video,
+            [
+                "-i",
+                input_video,
+                "-o",
+                "out.mkv",
+                "--spec",
+                "300/180",
+                "--sidecar-format",
+                "raw",
+            ],
+        )
+        mock_dm.assert_called_once()
+        assert mock_dm.call_args.kwargs["sidecar_format"] == "raw"
 
 
 # ===========================================================================

--- a/tests/qr/test_split_video.py
+++ b/tests/qr/test_split_video.py
@@ -597,6 +597,7 @@ def test_to_bids_model_full_mapping():
     assert data["Width"] == 1920
     assert data["Height"] == 1080
     assert data["VideoCodec"] == "h264"
+    assert data["VideoCodecRFC6381"] == "n/a"
     assert data["AudioCodec"] == "aac"
     assert data["AudioSampleRate"] == 48000.0
     assert data["AudioChannelCount"] == 2
@@ -655,10 +656,11 @@ def test_to_bids_model_numeric_types():
 
 
 def test_to_bids_model_video_codec_present_when_resolution_known():
-    """VideoCodec is included when video_codec is set (resolution present)."""
+    """VideoCodec and VideoCodecRFC6381 are included when video_codec is set."""
     sr = SplitResult(video_width="1920", video_height="1080", video_codec="h264")
     data = _to_bids_model(sr)
     assert data["VideoCodec"] == "h264"
+    assert data["VideoCodecRFC6381"] == "n/a"
 
 
 def test_to_bids_model_video_codec_absent_when_na():

--- a/tests/qr/test_split_video.py
+++ b/tests/qr/test_split_video.py
@@ -530,6 +530,7 @@ def _make_split_result() -> SplitResult:
         audio_bit_depth="16",
         audio_channel_count="2",
         audio_codec="aac",
+        video_codec="h264",
         orig_buffer_start="17:25:00.000",
         orig_buffer_end="17:38:00.000",
         orig_buffer_offset=1500.0,
@@ -595,6 +596,7 @@ def test_to_bids_model_full_mapping():
     assert data["FrameRate"] == 30.0
     assert data["Width"] == 1920
     assert data["Height"] == 1080
+    assert data["VideoCodec"] == "h264"
     assert data["AudioCodec"] == "aac"
     assert data["AudioSampleRate"] == 48000.0
     assert data["AudioChannelCount"] == 2
@@ -607,6 +609,7 @@ def test_to_bids_model_na_fields_omitted():
         video_frame_rate=25.0,
         video_width="n/a",
         video_height="n/a",
+        video_codec="n/a",
         audio_codec="n/a",
         audio_sample_rate="n/a",
         audio_channel_count="n/a",
@@ -615,6 +618,7 @@ def test_to_bids_model_na_fields_omitted():
 
     assert "Width" not in data
     assert "Height" not in data
+    assert "VideoCodec" not in data
     assert "AudioCodec" not in data
     assert "AudioSampleRate" not in data
     assert "AudioChannelCount" not in data
@@ -650,6 +654,20 @@ def test_to_bids_model_numeric_types():
     assert isinstance(data["AudioChannelCount"], int) and data["AudioChannelCount"] == 1
 
 
+def test_to_bids_model_video_codec_present_when_resolution_known():
+    """VideoCodec is included when video_codec is set (resolution present)."""
+    sr = SplitResult(video_width="1920", video_height="1080", video_codec="h264")
+    data = _to_bids_model(sr)
+    assert data["VideoCodec"] == "h264"
+
+
+def test_to_bids_model_video_codec_absent_when_na():
+    """VideoCodec is omitted when video_codec is 'n/a' (no video stream)."""
+    sr = SplitResult(video_width="n/a", video_height="n/a", video_codec="n/a")
+    data = _to_bids_model(sr)
+    assert "VideoCodec" not in data
+
+
 def test_to_bids_model_no_raw_fields():
     """BIDS output contains no raw SplitResult field names."""
     sr = _make_split_result()
@@ -659,6 +677,7 @@ def test_to_bids_model_no_raw_fields():
         "video_frame_rate",
         "video_width",
         "video_height",
+        "video_codec",
         "audio_codec",
         "audio_sample_rate",
         "audio_channel_count",

--- a/tests/qr/test_split_video.py
+++ b/tests/qr/test_split_video.py
@@ -599,6 +599,7 @@ def test_to_bids_model_full_mapping():
     assert data["VideoCodec"] == "h264"
     assert data["VideoCodecRFC6381"] == "n/a"
     assert data["AudioCodec"] == "aac"
+    assert data["AudioCodecRFC6381"] == "n/a"
     assert data["AudioSampleRate"] == 48000.0
     assert data["AudioChannelCount"] == 2
 


### PR DESCRIPTION
Pilot implementation of bids-inject generates sidecar JSON files using an internal BIDS-style format, which is not yet standardized. This is an interim solution aligned with ongoing work on BIDS BEP044/BEP047, and the data structure is expected to be refactored once the corresponding specifications are finalized.

Relevant issues/PR:
- https://github.com/bids-standard/bids-specification/pull/2367
- #14

Support for RFC6381 fields is not yet implemented. However, placeholder values (`n/a`) are included to maintain schema compatibility. Full implementation is deferred due to required upstream changes in `video-audit` and the `videos.tsv` merge.