### PR TITLE
Add `reprostim_` columns in _scans.tsv for `bids-inject` command

### DIFF
--- a/.ai/spec-bids-inject.md
+++ b/.ai/spec-bids-inject.md
@@ -86,9 +86,10 @@ sub-qa/ses-20250814/func/sub-qa_ses-20250814_acq-faX77_recording-reprostim_audio
 After a successful injection `bids-inject` writes back several `reprostim_*` columns to
 the same `_scans.tsv` row, recording the exact video provenance and timing offsets used.
 These columns are written **in-place** (the file is rewritten with the new columns appended
-to the right of any existing columns).  Columns are only set on rows that were successfully
-injected; rows that were skipped or errored are left unchanged (`n/a` written if the column
-is newly added to the file).
+to the right of any existing columns).  All four columns are always written for every row that `_call_split_video` is invoked for —
+`n/a` on failure or when `SplitResult` is unavailable, actual values on success.  Rows that
+were never matched to a video (skipped before `_call_split_video`) retain whatever value was
+already in the file (or `n/a` if the column is newly added).
 
 **Column name prefix — `reprostim_`:** the longer prefix is preferred over `r_` because it
 is self-documenting, unambiguous if multiple tools annotate the same scans file, and avoids
@@ -692,8 +693,12 @@ The two columns used by `bids-inject`:
 
 Other columns (`operator`, `randstr`, etc.) are ignored on read.
 
-After a successful injection, `bids-inject` appends the `reprostim_*` annotation columns
-(see Output section D above) back into the same file.
+After processing all scan records, `bids-inject` calls `_save_scans_model` to rewrite the
+`_scans.tsv` file with `reprostim_*` annotation columns appended (see Output D above).
+Write-back is skipped in `--dry-run` mode.  `_save_scans_model` derives the output fieldnames
+from the existing `ScanRecord.extra` keys (preserving column order) and then appends any
+`_REPROSTIM_COLS` not already present.  It uses `csv.DictWriter` with `extrasaction="ignore"`
+and Unix line endings (`\n`).
 
 **Filtering rules** — a scan row is processed only if both conditions are met:
 

--- a/.ai/spec-bids-inject.md
+++ b/.ai/spec-bids-inject.md
@@ -81,6 +81,40 @@ Example:
 sub-qa/ses-20250814/func/sub-qa_ses-20250814_acq-faX77_recording-reprostim_audiovideo.json
 ```
 
+### D) _scans.tsv annotation — reprostim columns
+
+After a successful injection `bids-inject` writes back several `reprostim_*` columns to
+the same `_scans.tsv` row, recording the exact video provenance and timing offsets used.
+These columns are written **in-place** (the file is rewritten with the new columns appended
+to the right of any existing columns).  Columns are only set on rows that were successfully
+injected; rows that were skipped or errored are left unchanged (`n/a` written if the column
+is newly added to the file).
+
+**Column name prefix — `reprostim_`:** the longer prefix is preferred over `r_` because it
+is self-documenting, unambiguous if multiple tools annotate the same scans file, and avoids
+namespace collisions.
+
+| Column                     | Source in `SplitResult`   | Description                                                                                   |
+|----------------------------|---------------------------|-----------------------------------------------------------------------------------------------|
+| `reprostim_buffer_before`  | `buffer_before`           | Actual buffer prepended before scan onset, in seconds.                                        |
+| `reprostim_buffer_after`   | `buffer_after`            | Actual buffer appended after scan end, in seconds.                                            |
+| `reprostim_path`           | `input_path` (relative)   | Path to the source `.mkv` file, relative to the `videos.tsv` location.                       |
+| `reprostim_offset`         | `orig_buffer_offset`      | Offset of the buffer-segment start into the source video, in seconds (`buf_seg.offset_sec`).  |
+
+**Example extended `_scans.tsv`:**
+```
+filename                                                              acq_time                    operator  randstr   reprostim_buffer_before  reprostim_buffer_after  reprostim_path                              reprostim_offset
+func/sub-qa_ses-20250814_acq-faX77_bold.nii.gz                       2025-08-14T15:19:53.397500  n/a       6b371aad  10.0                     10.0                    2025.08.14.15.10.00.000_....mkv             560.3
+func/sub-qa_ses-20250814_task-rest_acq-p2_bold__dup-01.nii.gz        2025-08-14T15:06:09.742500  n/a       77b0dbb6  n/a                      n/a                     n/a                                         n/a
+```
+
+> **Future (QR-based improvement):** When QR codes are embedded in the source video and
+> have already been parsed (stored in `videos.tsv` or alongside the video as JSONL), the
+> injection offset and buffer boundaries can be refined using QR timestamps rather than
+> relying solely on NTP-based `acq_time`.  Recording `reprostim_offset` in `_scans.tsv`
+> makes it possible to resume or validate a subsequent `bids-qr-sync` pass without
+> re-scanning the source video from scratch.
+
 ### C) QR codes file — BIDS _events-like .tsv
 
 If QR codes were parsed from the video (`--qr` mode is not `none`), the decoded QR records
@@ -656,7 +690,10 @@ The two columns used by `bids-inject`:
 | `filename`   | Relative path to the NIfTI file within the subject/session directory. Used to derive the output `.mkv` basename and locate the corresponding DICOM JSON sidecar for duration computation. |
 | `acq_time`   | ISO 8601 datetime of scan acquisition start. Combined with `--time-offset`, this is matched against the `start_time`/`end_time` range in `videos.tsv` to find the covering video file.    |
 
-Other columns (`operator`, `randstr`, etc.) are ignored.
+Other columns (`operator`, `randstr`, etc.) are ignored on read.
+
+After a successful injection, `bids-inject` appends the `reprostim_*` annotation columns
+(see Output section D above) back into the same file.
 
 **Filtering rules** — a scan row is processed only if both conditions are met:
 
@@ -737,3 +774,4 @@ Registered in `src/reprostim/cli/entrypoint.py` alongside other commands.
 11. **Parallel processing**: The natural parallelism granularity is one `_scans.tsv` per worker (scans within a session stay sequential). When multiple sessions run concurrently, shared output data (summary counters, QR JSONL cache, any merged report files) will need lock protection. To be designed when a `--jobs` option is introduced.
 12. **con/duct**: ideally -- should have also used duct
 13. ~~**Error processing**: Add an option on what to do about "problematic" cases.~~ → partially resolved as `-w / --overwrite [skip|force|always|error]` for existing output handling.
+14. **QR-assisted injection resume**: When QR codes are already parsed and stored alongside the source video, `reprostim_offset` written to `_scans.tsv` (output D) enables a future `bids-qr-sync` pass to refine timing without re-scanning the video. Design the handoff protocol between `bids-inject` and `bids-qr-sync`.

--- a/.ai/task-bids-inject.md
+++ b/.ai/task-bids-inject.md
@@ -245,11 +245,12 @@ Test file location: `tests/qr/test_bids_inject.py` (mirrors `tests/audio/test_au
 - [x] `_save_scans_model` — `reprostim_*` columns appear in `_REPROSTIM_COLS` order
 
 #### Integration tests (end-to-end via `_do_inject_scans` / `_call_split_video`)
-- [ ] Successful injection → all four `reprostim_*` columns written with correct values
-- [ ] Failed split → four columns written as `n/a` (stale values cleared)
-- [ ] Re-run (columns already present) → columns updated in-place, no duplication
-- [ ] `--dry-run` → `_scans.tsv` not modified
-- [ ] `reprostim_path` is relative to `videos.tsv` location, not absolute
+- [x] Successful injection → all four `reprostim_*` columns written with correct values
+- [x] `reprostim_path` is relative to `videos.tsv` location, not absolute
+- [x] Non-injected rows receive `n/a` for all `reprostim_*` columns
+- [x] Failed split → four columns written as `n/a` (stale values cleared)
+- [x] Re-run (columns already present) → columns updated in-place, no duplication
+- [x] `--dry-run` → `_scans.tsv` not modified
 
 ### Overwrite mode tests
 

--- a/.ai/task-bids-inject.md
+++ b/.ai/task-bids-inject.md
@@ -120,13 +120,13 @@ Tracks implementation progress against [spec-bids-inject.md](spec-bids-inject.md
 - [ ] Columns: `onset`, `duration`, plus QR-derived fields
 
 ### D) _scans.tsv annotation — `reprostim_*` columns
-- [ ] Add `ScansModel` / `ScanRecord` fields for the four annotation columns
-- [ ] Write-back `reprostim_buffer_before`, `reprostim_buffer_after`, `reprostim_path`, `reprostim_offset` to `_scans.tsv` after successful injection
-- [ ] Rows that are skipped or error → write `n/a` for all four columns (when column is newly added to file)
-- [ ] Preserve all existing columns; append new ones to the right
-- [ ] Handle re-runs: update existing `reprostim_*` columns in-place (don't duplicate)
-- [ ] Skip write-back in `--dry-run` mode
-- [ ] `reprostim_path` stored relative to `videos.tsv` location (consistent with `videos.tsv` path convention)
+- [x] Add `ScansModel` / `ScanRecord` fields for the four annotation columns
+- [x] Write-back `reprostim_buffer_before`, `reprostim_buffer_after`, `reprostim_path`, `reprostim_offset` to `_scans.tsv` after successful injection
+- [x] Rows that are skipped or error → write `n/a` for all four columns (when column is newly added to file)
+- [x] Preserve all existing columns; append new ones to the right
+- [x] Handle re-runs: update existing `reprostim_*` columns in-place (don't duplicate)
+- [x] Skip write-back in `--dry-run` mode
+- [x] `reprostim_path` stored relative to `videos.tsv` location (consistent with `videos.tsv` path convention)
 
 ---
 
@@ -230,8 +230,23 @@ Test file location: `tests/qr/test_bids_inject.py` (mirrors `tests/audio/test_au
 
 ### _scans.tsv annotation tests
 
+#### Unit tests (helpers + parse/save APIs)
+- [x] `_parse_bids_float` — valid float string, integer string, `n/a`, `None`, empty string
+- [x] `_parse_bids_str` — valid string, `n/a`, `None`, empty string
+- [x] `_format_bids_str` — `None` → `"n/a"`, float, string passthrough, zero
+- [x] `_REPROSTIM_COLS` — constant exported and used in both parse and save
+- [x] `_parse_scans_model` — `reprostim_*` columns absent → fields default to `None`
+- [x] `_parse_scans_model` — `reprostim_*` columns present → fields populated correctly
+- [x] `_parse_scans_model` — `n/a` values → fields parse to `None`
+- [x] `_parse_scans_model` — `reprostim_*` columns NOT stored in `extra`
+- [x] `_save_scans_model` — appends `reprostim_*` columns after existing columns
+- [x] `_save_scans_model` — `None` values written as `"n/a"`
+- [x] `_save_scans_model` — existing extra columns preserved
+- [x] `_save_scans_model` — `reprostim_*` columns appear in `_REPROSTIM_COLS` order
+
+#### Integration tests (end-to-end via `_do_inject_scans` / `_call_split_video`)
 - [ ] Successful injection → all four `reprostim_*` columns written with correct values
-- [ ] Skipped scan → four columns written as `n/a`
+- [ ] Failed split → four columns written as `n/a` (stale values cleared)
 - [ ] Re-run (columns already present) → columns updated in-place, no duplication
 - [ ] `--dry-run` → `_scans.tsv` not modified
 - [ ] `reprostim_path` is relative to `videos.tsv` location, not absolute

--- a/.ai/task-bids-inject.md
+++ b/.ai/task-bids-inject.md
@@ -119,6 +119,15 @@ Tracks implementation progress against [spec-bids-inject.md](spec-bids-inject.md
 - [ ] Finalise suffix name (`_qrcodes` / `_codes` / `_qr` / `_qrinfo`)
 - [ ] Columns: `onset`, `duration`, plus QR-derived fields
 
+### D) _scans.tsv annotation — `reprostim_*` columns
+- [ ] Add `ScansModel` / `ScanRecord` fields for the four annotation columns
+- [ ] Write-back `reprostim_buffer_before`, `reprostim_buffer_after`, `reprostim_path`, `reprostim_offset` to `_scans.tsv` after successful injection
+- [ ] Rows that are skipped or error → write `n/a` for all four columns (when column is newly added to file)
+- [ ] Preserve all existing columns; append new ones to the right
+- [ ] Handle re-runs: update existing `reprostim_*` columns in-place (don't duplicate)
+- [ ] Skip write-back in `--dry-run` mode
+- [ ] `reprostim_path` stored relative to `videos.tsv` location (consistent with `videos.tsv` path convention)
+
 ---
 
 ## QR Modes
@@ -218,6 +227,14 @@ Test file location: `tests/qr/test_bids_inject.py` (mirrors `tests/audio/test_au
 - [ ] `--lock no` → `FileLock` not acquired (mock / spy on `_get_tsv_records`)
 - [ ] `--reprostim-timezone` / `--bids-timezone` → passed into `BiContext` correctly
 - [ ] Mixed timezone scenario: Eastern ReproStim + UTC BIDS → times align after conversion
+
+### _scans.tsv annotation tests
+
+- [ ] Successful injection → all four `reprostim_*` columns written with correct values
+- [ ] Skipped scan → four columns written as `n/a`
+- [ ] Re-run (columns already present) → columns updated in-place, no duplication
+- [ ] `--dry-run` → `_scans.tsv` not modified
+- [ ] `reprostim_path` is relative to `videos.tsv` location, not absolute
 
 ### Overwrite mode tests
 

--- a/src/reprostim/cli/cmd_split_video.py
+++ b/src/reprostim/cli/cmd_split_video.py
@@ -217,7 +217,7 @@ def split_video(
     # Record start time
     start_time_sec = time.time()
 
-    res = do_main(
+    res, _ = do_main(
         input_path=input_path,
         output_path=output,
         start_time=start,

--- a/src/reprostim/qr/bids_inject.py
+++ b/src/reprostim/qr/bids_inject.py
@@ -892,7 +892,7 @@ def _call_split_video(
     if record.metadata and record.metadata.TaskName:
         sidecar_metadata["TaskName"] = record.metadata.TaskName
 
-    ret, _ = split_video_main(
+    ret, split_results = split_video_main(
         input_path=input_path,
         output_path=output_path,
         start_time=start_ts.isoformat(),
@@ -908,6 +908,13 @@ def _call_split_video(
         verbose=ctx.verbose,
         out_func=_capturing_out_func,
     )
+
+    # reset reprostim_ data first
+    record.reprostim_path = None
+    record.reprostim_offset = None
+    record.reprostim_buffer_before = None
+    record.reprostim_buffer_after = None
+
     if ret != 0:
         captured = "; ".join(captured_errors) if captured_errors else f"exit code {ret}"
         err_msg = f"split-video failed for {record.filename}: {captured}"
@@ -917,6 +924,12 @@ def _call_split_video(
     else:
         logger.info(f"split-video completed successfully ({record.filename})")
         ctx.summary.n_injected += 1
+        if split_results:
+            sr = split_results[0]
+            record.reprostim_path = va.path
+            record.reprostim_offset = sr.orig_buffer_offset
+            record.reprostim_buffer_before = sr.buffer_before
+            record.reprostim_buffer_after = sr.buffer_after
 
 
 def _do_inject_scans(ctx: BiContext, path: str):
@@ -1008,6 +1021,8 @@ def _do_inject_scans(ctx: BiContext, path: str):
             else:
                 logger.debug(f"Skipping scan record (no match): {sr.filename}")
                 ctx.summary.n_skipped += 1
+        if not ctx.dry_run:
+            _save_scans_model(scans)
     else:
         logger.warning(f"Skipping non-_scans.tsv file: {path}")
 

--- a/src/reprostim/qr/bids_inject.py
+++ b/src/reprostim/qr/bids_inject.py
@@ -310,6 +310,15 @@ class ScansModel(BaseModel):
 ####################################################################
 
 
+# Ordered list of reprostim_* annotation columns read from and written to _scans.tsv.
+_REPROSTIM_COLS = [
+    "reprostim_path",
+    "reprostim_offset",
+    "reprostim_buffer_before",
+    "reprostim_buffer_after",
+]
+
+
 def _parse_bids_float(value: Optional[str]) -> Optional[float]:
     """Parse an optional TSV cell as float, returning ``None`` for ``'n/a'`` or absent.
 
@@ -332,6 +341,16 @@ def _parse_bids_str(value: Optional[str]) -> Optional[str]:
     :rtype: Optional[str]
     """
     return value if value and value != "n/a" else None
+
+
+def _format_bids_str(value) -> str:
+    """Serialise a field value to a TSV cell string, using ``'n/a'`` for ``None``.
+
+    :param value: Value to serialise; any type accepted by ``str()``.
+    :returns: String representation, or ``'n/a'`` when *value* is ``None``.
+    :rtype: str
+    """
+    return "n/a" if value is None else str(value)
 
 
 def _is_scans_file(path: str) -> bool:
@@ -429,13 +448,7 @@ def _parse_scans_model(path: str) -> ScansModel:
     :raises KeyError: If a required column (``filename`` or ``acq_time``) is
         missing from the TSV header.
     """
-    _reprostim_keys = {
-        "reprostim_path",
-        "reprostim_offset",
-        "reprostim_buffer_before",
-        "reprostim_buffer_after",
-    }
-    _known = {"filename", "acq_time"} | _reprostim_keys
+    _known = {"filename", "acq_time"} | set(_REPROSTIM_COLS)
 
     records: List[ScanRecord] = []
     with open(path, newline="", encoding="utf-8") as f:
@@ -458,6 +471,54 @@ def _parse_scans_model(path: str) -> ScansModel:
             )
     logger.debug(f"Parsed {len(records)} scan records from: {path}")
     return ScansModel(path=path, records=records)
+
+
+def _save_scans_model(model: ScansModel) -> None:
+    """Write :class:`ScansModel` records back to the ``*_scans.tsv`` file.
+
+    Derives column order from the already-parsed model data: ``filename`` and
+    ``acq_time`` first, then any extra columns (in their original order from
+    :attr:`ScanRecord.extra`), then ``reprostim_*`` annotation columns from
+    :data:`_REPROSTIM_COLS` appended on the right.  ``None`` field values are
+    serialised as ``'n/a'`` via :func:`_format_bids_str`.
+
+    :param model: Scans model to persist.  :attr:`~ScansModel.path` must be
+        writable.
+    :type model: ScansModel
+    """
+    # Derive extra column names from the first record (order preserved by dict).
+    extra_cols = list(model.records[0].extra.keys()) if model.records else []
+    fieldnames = (
+        ["filename", "acq_time"]
+        + extra_cols
+        + [c for c in _REPROSTIM_COLS if c not in extra_cols]
+    )
+
+    rows = []
+    for record in model.records:
+        row = {
+            "filename": record.filename,
+            "acq_time": record.acq_time,
+            **record.extra,
+            "reprostim_path": _format_bids_str(record.reprostim_path),
+            "reprostim_offset": _format_bids_str(record.reprostim_offset),
+            "reprostim_buffer_before": _format_bids_str(record.reprostim_buffer_before),
+            "reprostim_buffer_after": _format_bids_str(record.reprostim_buffer_after),
+        }
+        rows.append(row)
+
+    with open(model.path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=fieldnames,
+            delimiter="\t",
+            extrasaction="ignore",
+            lineterminator="\n",
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+    logger.debug(f"Saved {len(rows)} scan records to: {model.path}")
 
 
 def _calc_scan_duration_sec(record: ScanRecord) -> Optional[float]:

--- a/src/reprostim/qr/bids_inject.py
+++ b/src/reprostim/qr/bids_inject.py
@@ -272,6 +272,25 @@ class ScanRecord(BaseModel):
         default=None,
         description="Scan duration in seconds, computed from sidecar metadata.",
     )
+    # reprostim_* annotation columns — read from _scans.tsv when present (prior run),
+    # written back after successful injection.
+    reprostim_path: Optional[str] = Field(
+        default=None,
+        description="Path to source .mkv file relative to videos.tsv location.",
+    )
+    reprostim_offset: Optional[float] = Field(
+        default=None,
+        description="Offset of the buffer-segment start into the source video, "
+        "in seconds.",
+    )
+    reprostim_buffer_before: Optional[float] = Field(
+        default=None,
+        description="Actual buffer prepended before scan onset, in seconds.",
+    )
+    reprostim_buffer_after: Optional[float] = Field(
+        default=None,
+        description="Actual buffer appended after scan end, in seconds.",
+    )
 
 
 class ScansModel(BaseModel):
@@ -289,6 +308,30 @@ class ScansModel(BaseModel):
 ####################################################################
 # Internal API
 ####################################################################
+
+
+def _parse_bids_float(value: Optional[str]) -> Optional[float]:
+    """Parse an optional TSV cell as float, returning ``None`` for ``'n/a'`` or absent.
+
+    :param value: Raw cell string from a TSV row, or ``None`` when the column
+        was not present in the file.
+    :type value: Optional[str]
+    :returns: Parsed float, or ``None``.
+    :rtype: Optional[float]
+    """
+    return float(value) if value and value != "n/a" else None
+
+
+def _parse_bids_str(value: Optional[str]) -> Optional[str]:
+    """Return a TSV cell string as-is, or ``None`` for ``'n/a'`` or absent.
+
+    :param value: Raw cell string from a TSV row, or ``None`` when the column
+        was not present in the file.
+    :type value: Optional[str]
+    :returns: The string value, or ``None``.
+    :rtype: Optional[str]
+    """
+    return value if value and value != "n/a" else None
 
 
 def _is_scans_file(path: str) -> bool:
@@ -386,6 +429,14 @@ def _parse_scans_model(path: str) -> ScansModel:
     :raises KeyError: If a required column (``filename`` or ``acq_time``) is
         missing from the TSV header.
     """
+    _reprostim_keys = {
+        "reprostim_path",
+        "reprostim_offset",
+        "reprostim_buffer_before",
+        "reprostim_buffer_after",
+    }
+    _known = {"filename", "acq_time"} | _reprostim_keys
+
     records: List[ScanRecord] = []
     with open(path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter="\t")
@@ -394,11 +445,15 @@ def _parse_scans_model(path: str) -> ScansModel:
                 ScanRecord(
                     filename=row["filename"],
                     acq_time=row["acq_time"],
-                    extra={
-                        k: v
-                        for k, v in row.items()
-                        if k not in ("filename", "acq_time")
-                    },
+                    extra={k: v for k, v in row.items() if k not in _known},
+                    reprostim_path=_parse_bids_str(row.get("reprostim_path")),
+                    reprostim_offset=_parse_bids_float(row.get("reprostim_offset")),
+                    reprostim_buffer_before=_parse_bids_float(
+                        row.get("reprostim_buffer_before")
+                    ),
+                    reprostim_buffer_after=_parse_bids_float(
+                        row.get("reprostim_buffer_after")
+                    ),
                 )
             )
     logger.debug(f"Parsed {len(records)} scan records from: {path}")

--- a/src/reprostim/qr/bids_inject.py
+++ b/src/reprostim/qr/bids_inject.py
@@ -892,7 +892,7 @@ def _call_split_video(
     if record.metadata and record.metadata.TaskName:
         sidecar_metadata["TaskName"] = record.metadata.TaskName
 
-    ret = split_video_main(
+    ret, _ = split_video_main(
         input_path=input_path,
         output_path=output_path,
         start_time=start_ts.isoformat(),

--- a/src/reprostim/qr/split_video.py
+++ b/src/reprostim/qr/split_video.py
@@ -13,7 +13,7 @@ import os
 import subprocess
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import isodate
 from pydantic import BaseModel, Field
@@ -792,7 +792,7 @@ def _do_main_specs(
     verbose: bool = False,
     lock: bool = True,
     out_func=print,
-) -> int:
+) -> Tuple[int, List["SplitResult"]]:
     """Process multiple --spec arguments.
 
     :param specs: Tuple of spec strings
@@ -806,7 +806,7 @@ def _do_main_specs(
     :param raw: Enable raw mode
     :param verbose: Enable verbose output
     :param out_func: Output function
-    :return: Number of failures (0 = all succeeded)
+    :return: Tuple of (number of failures, list of successful SplitResult objects)
     """
     # Validate output template for multiple specs
     if len(specs) > 1 and not _has_template_tokens(output_template):
@@ -828,6 +828,7 @@ def _do_main_specs(
         )
 
     failures = 0
+    results: List[SplitResult] = []
     buf_before_sec = _parse_interval_sec(buffer_before)
     buf_after_sec = _parse_interval_sec(buffer_after)
     bp = BufferPolicy(buffer_policy.lower())
@@ -887,6 +888,8 @@ def _do_main_specs(
                 failures += 1
                 continue
 
+            results.append(sr)
+
             if verbose:
                 out_func(f"  Input path  : {sr.input_path}")
                 out_func(f"  Output path : {sr.output_path}")
@@ -913,7 +916,7 @@ def _do_main_specs(
             failures += 1
             continue
 
-    return failures
+    return failures, results
 
 
 def do_main(
@@ -934,7 +937,7 @@ def do_main(
     specs: tuple = (),
     lock: bool = True,
     out_func=print,
-) -> int:
+) -> Tuple[int, List[SplitResult]]:
     """Main entry point for split_video module.
 
     Parameters
@@ -1030,7 +1033,7 @@ def do_main(
             logger.error(
                 "Either --spec or --start with --duration/--end must be provided."
             )
-            return 1
+            return 1, []
 
     try:
         return _do_main_specs(
@@ -1052,4 +1055,4 @@ def do_main(
     except ValueError as e:
         logger.error(f"Spec validation error: {e}")
         out_func(f"ERROR: {e}")
-        return 5
+        return 5, []

--- a/tests/qr/test_bids_inject.py
+++ b/tests/qr/test_bids_inject.py
@@ -983,7 +983,7 @@ def test_call_split_video_passes_task_name_in_sidecar_metadata(tmp_path):
 
     def _fake_split_video_main(**kwargs):
         captured.update(kwargs)
-        return 0
+        return 0, []
 
     with patch("reprostim.qr.split_video.do_main", side_effect=_fake_split_video_main):
         ret, _ = _run(
@@ -1016,7 +1016,7 @@ def test_call_split_video_empty_sidecar_metadata_when_no_task_name(tmp_path):
 
     def _fake_split_video_main(**kwargs):
         captured.update(kwargs)
-        return 0
+        return 0, []
 
     with patch("reprostim.qr.split_video.do_main", side_effect=_fake_split_video_main):
         ret, _ = _run(

--- a/tests/qr/test_bids_inject.py
+++ b/tests/qr/test_bids_inject.py
@@ -4,6 +4,7 @@
 
 """Tests for the Datetime / Timezone public API in reprostim.qr.bids_inject."""
 
+import csv
 import re
 import shutil
 from datetime import datetime, time, timezone
@@ -46,6 +47,7 @@ from reprostim.qr.bids_inject import (
     dt_utc_to_bids,
     dt_utc_to_reprostim,
 )
+from reprostim.qr.split_video import SplitResult
 
 # ---------------------------------------------------------------------------
 # Shared fixtures / helpers
@@ -1251,10 +1253,8 @@ def test_save_scans_model_reprostim_cols_order(tmp_path):
     model = _make_scans_model(tmp_path)
     _save_scans_model(model)
 
-    import csv as _csv
-
     with open(model.path, newline="", encoding="utf-8") as f:
-        fieldnames = list(_csv.DictReader(f, delimiter="\t").fieldnames or [])
+        fieldnames = list(csv.DictReader(f, delimiter="\t").fieldnames or [])
 
     reprostim_positions = [fieldnames.index(c) for c in _REPROSTIM_COLS]
     assert reprostim_positions == sorted(
@@ -1283,10 +1283,163 @@ def test_save_scans_model_idempotent(tmp_path):
     model2.records[0].reprostim_path = "video1.mkv"
     _save_scans_model(model2)
 
-    import csv as _csv
-
     with open(model.path, newline="", encoding="utf-8") as f:
-        fieldnames = list(_csv.DictReader(f, delimiter="\t").fieldnames or [])
+        fieldnames = list(csv.DictReader(f, delimiter="\t").fieldnames or [])
 
     for col in _REPROSTIM_COLS:
         assert fieldnames.count(col) == 1, f"Column '{col}' duplicated after two saves"
+
+
+# ===========================================================================
+# _scans.tsv annotation write-back (integration)
+# ===========================================================================
+
+
+def _fake_split_result(*, buffer_before=5.0, buffer_after=3.0, orig_buffer_offset=69.7):
+    """Build a SplitResult with known field values for testing."""
+    return SplitResult(
+        success=True,
+        buffer_before=buffer_before,
+        buffer_after=buffer_after,
+        orig_buffer_offset=orig_buffer_offset,
+    )
+
+
+def _tsv_rows(path: Path) -> dict:
+    """Read TSV into {filename: row_dict}."""
+    with open(path, newline="", encoding="utf-8") as f:
+        return {r["filename"]: r for r in csv.DictReader(f, delimiter="\t")}
+
+
+def test_scans_tsv_successful_injection_writes_reprostim_cols(tmp_path):
+    """Successful injection → reprostim_* columns written with correct values.
+
+    Also verifies reprostim_path is stored relative to the videos.tsv directory
+    and that non-injected rows receive n/a.
+    """
+    scans_tsv = _copy_bids_fixture(tmp_path)
+    videos_tsv = _write_videos_tsv(tmp_path, _VA_V1)  # va.path == "video1.mkv"
+
+    sr = _fake_split_result(
+        buffer_before=5.0, buffer_after=3.0, orig_buffer_offset=69.7
+    )
+
+    def _fake_split(**kwargs):
+        return 0, [sr]
+
+    with patch("reprostim.qr.split_video.do_main", side_effect=_fake_split):
+        _run(
+            [str(scans_tsv)],
+            videos_tsv,
+            match=_MATCH_TASK_REST,
+            dry_run=False,
+            overwrite="always",
+        )
+
+    rows = _tsv_rows(scans_tsv)
+    matched = rows["func/sub-qa_ses-20250814_task-rest_acq-p2_bold.nii.gz"]
+    assert matched["reprostim_path"] == "video1.mkv"
+    assert float(matched["reprostim_offset"]) == pytest.approx(69.7)
+    assert float(matched["reprostim_buffer_before"]) == pytest.approx(5.0)
+    assert float(matched["reprostim_buffer_after"]) == pytest.approx(3.0)
+    # Non-injected rows get n/a.
+    anat = rows["anat/sub-qa_ses-20250814_T1w.nii.gz"]
+    for col in _REPROSTIM_COLS:
+        assert anat[col] == "n/a"
+
+
+def test_scans_tsv_failed_split_clears_stale_reprostim_cols(tmp_path):
+    """split-video failure → reprostim_* written as n/a, clearing any stale values."""
+    scans_tsv = _copy_bids_fixture(tmp_path)
+    videos_tsv = _write_videos_tsv(tmp_path, _VA_V1)
+
+    # Pre-populate reprostim_* with stale values (simulates a prior successful run).
+    model = _parse_scans_model(str(scans_tsv))
+    for rec in model.records:
+        if rec.filename.endswith("task-rest_acq-p2_bold.nii.gz"):
+            rec.reprostim_path = "old_video.mkv"
+            rec.reprostim_offset = 999.0
+            rec.reprostim_buffer_before = 20.0
+            rec.reprostim_buffer_after = 20.0
+    _save_scans_model(model)
+
+    def _fake_split(**kwargs):
+        return 1, []  # failure
+
+    with patch("reprostim.qr.split_video.do_main", side_effect=_fake_split):
+        _run(
+            [str(scans_tsv)],
+            videos_tsv,
+            match=_MATCH_TASK_REST,
+            dry_run=False,
+            overwrite="always",
+        )
+
+    matched = _tsv_rows(scans_tsv)[
+        "func/sub-qa_ses-20250814_task-rest_acq-p2_bold.nii.gz"
+    ]
+    for col in _REPROSTIM_COLS:
+        assert matched[col] == "n/a", f"{col} should be n/a after failed split"
+
+
+def test_scans_tsv_rerun_updates_in_place_no_duplication(tmp_path):
+    """Re-run with existing reprostim_* columns → values updated,
+    no column duplication."""
+    scans_tsv = _copy_bids_fixture(tmp_path)
+    videos_tsv = _write_videos_tsv(tmp_path, _VA_V1)
+
+    # Simulate a prior run with old values.
+    model = _parse_scans_model(str(scans_tsv))
+    for rec in model.records:
+        if rec.filename.endswith("task-rest_acq-p2_bold.nii.gz"):
+            rec.reprostim_path = "old_video.mkv"
+            rec.reprostim_offset = 100.0
+            rec.reprostim_buffer_before = 0.0
+            rec.reprostim_buffer_after = 0.0
+    _save_scans_model(model)
+
+    sr = _fake_split_result(
+        buffer_before=10.0, buffer_after=8.0, orig_buffer_offset=42.5
+    )
+
+    def _fake_split(**kwargs):
+        return 0, [sr]
+
+    with patch("reprostim.qr.split_video.do_main", side_effect=_fake_split):
+        _run(
+            [str(scans_tsv)],
+            videos_tsv,
+            match=_MATCH_TASK_REST,
+            dry_run=False,
+            overwrite="always",
+        )
+
+    with open(scans_tsv, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        fieldnames = list(reader.fieldnames or [])
+        rows = {r["filename"]: r for r in reader}
+
+    for col in _REPROSTIM_COLS:
+        assert fieldnames.count(col) == 1, f"Column '{col}' duplicated after re-run"
+
+    matched = rows["func/sub-qa_ses-20250814_task-rest_acq-p2_bold.nii.gz"]
+    assert float(matched["reprostim_offset"]) == pytest.approx(42.5)
+    assert float(matched["reprostim_buffer_before"]) == pytest.approx(10.0)
+    assert float(matched["reprostim_buffer_after"]) == pytest.approx(8.0)
+
+
+def test_scans_tsv_dry_run_does_not_modify_file(tmp_path):
+    """--dry-run → _scans.tsv is not modified even when a video match is found."""
+    scans_tsv = _copy_bids_fixture(tmp_path)
+    videos_tsv = _write_videos_tsv(tmp_path, _VA_V1)
+    original_content = scans_tsv.read_text(encoding="utf-8")
+
+    _run(
+        [str(scans_tsv)],
+        videos_tsv,
+        match=_MATCH_TASK_REST,
+        dry_run=True,
+        overwrite="always",
+    )
+
+    assert scans_tsv.read_text(encoding="utf-8") == original_content

--- a/tests/qr/test_bids_inject.py
+++ b/tests/qr/test_bids_inject.py
@@ -15,6 +15,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import pytest
 
 from reprostim.qr.bids_inject import (
+    _REPROSTIM_COLS,
     MediaSuffix,
     ScanMetadata,
     ScanRecord,
@@ -24,8 +25,13 @@ from reprostim.qr.bids_inject import (
     _calc_scan_duration_sec,
     _calc_scan_start_end_ts,
     _find_bids_root,
+    _format_bids_str,
     _is_scans_file,
+    _parse_bids_float,
+    _parse_bids_str,
     _parse_scan_metadata,
+    _parse_scans_model,
+    _save_scans_model,
     do_main,
     dt_bids_to_reprostim,
     dt_bids_to_utc,
@@ -1024,3 +1030,263 @@ def test_call_split_video_empty_sidecar_metadata_when_no_task_name(tmp_path):
     assert ret == 0
     assert "sidecar_metadata" in captured
     assert captured["sidecar_metadata"] == {}
+
+
+# ===========================================================================
+# _parse_bids_float
+# ===========================================================================
+
+
+def test_parse_bids_float_valid():
+    assert _parse_bids_float("10.5") == 10.5
+
+
+def test_parse_bids_float_integer_string():
+    assert _parse_bids_float("5") == 5.0
+
+
+def test_parse_bids_float_na_returns_none():
+    assert _parse_bids_float("n/a") is None
+
+
+def test_parse_bids_float_none_returns_none():
+    assert _parse_bids_float(None) is None
+
+
+def test_parse_bids_float_empty_string_returns_none():
+    assert _parse_bids_float("") is None
+
+
+# ===========================================================================
+# _parse_bids_str
+# ===========================================================================
+
+
+def test_parse_bids_str_valid():
+    assert _parse_bids_str("video1.mkv") == "video1.mkv"
+
+
+def test_parse_bids_str_na_returns_none():
+    assert _parse_bids_str("n/a") is None
+
+
+def test_parse_bids_str_none_returns_none():
+    assert _parse_bids_str(None) is None
+
+
+def test_parse_bids_str_empty_string_returns_none():
+    assert _parse_bids_str("") is None
+
+
+# ===========================================================================
+# _format_bids_str
+# ===========================================================================
+
+
+def test_format_bids_str_none_returns_na():
+    assert _format_bids_str(None) == "n/a"
+
+
+def test_format_bids_str_float():
+    assert _format_bids_str(10.5) == "10.5"
+
+
+def test_format_bids_str_string_passthrough():
+    assert _format_bids_str("video1.mkv") == "video1.mkv"
+
+
+def test_format_bids_str_zero():
+    assert _format_bids_str(0.0) == "0.0"
+
+
+# ===========================================================================
+# _parse_scans_model — reprostim_* columns
+# ===========================================================================
+
+
+def _write_scans_tsv(path: Path, rows: list[str], header: str) -> None:
+    path.write_text("\n".join([header] + rows) + "\n", encoding="utf-8")
+
+
+def test_parse_scans_model_reprostim_cols_absent(tmp_path):
+    """reprostim_* fields default to None when columns are not in the TSV."""
+    tsv = tmp_path / "sub-qa_ses-20250814_scans.tsv"
+    _write_scans_tsv(
+        tsv,
+        ["func/bold.nii.gz\t2025-08-14T15:06:09.742500\tn/a\tabc123"],
+        "filename\tacq_time\toperator\trandstr",
+    )
+    model = _parse_scans_model(str(tsv))
+    r = model.records[0]
+    assert r.reprostim_path is None
+    assert r.reprostim_offset is None
+    assert r.reprostim_buffer_before is None
+    assert r.reprostim_buffer_after is None
+
+
+def test_parse_scans_model_reprostim_cols_present(tmp_path):
+    """reprostim_* fields are parsed correctly when columns exist in the TSV."""
+    tsv = tmp_path / "sub-qa_ses-20250814_scans.tsv"
+    _write_scans_tsv(
+        tsv,
+        [
+            "func/bold.nii.gz\t2025-08-14T15:06:09.742500\tn/a\tabc123"
+            "\tvideo1.mkv\t560.3\t10.0\t10.0"
+        ],
+        "filename\tacq_time\toperator\trandstr"
+        "\treprostim_path\treprostim_offset\treprostim_buffer_before\t"
+        "reprostim_buffer_after",
+    )
+    model = _parse_scans_model(str(tsv))
+    r = model.records[0]
+    assert r.reprostim_path == "video1.mkv"
+    assert r.reprostim_offset == 560.3
+    assert r.reprostim_buffer_before == 10.0
+    assert r.reprostim_buffer_after == 10.0
+
+
+def test_parse_scans_model_reprostim_cols_na(tmp_path):
+    """reprostim_* fields become None when TSV cells contain 'n/a'."""
+    tsv = tmp_path / "sub-qa_ses-20250814_scans.tsv"
+    _write_scans_tsv(
+        tsv,
+        [
+            "func/bold.nii.gz\t2025-08-14T15:06:09.742500\tn/a\tabc123"
+            "\tn/a\tn/a\tn/a\tn/a"
+        ],
+        "filename\tacq_time\toperator\trandstr"
+        "\treprostim_path\treprostim_offset\treprostim_buffer_before\t"
+        "reprostim_buffer_after",
+    )
+    model = _parse_scans_model(str(tsv))
+    r = model.records[0]
+    assert r.reprostim_path is None
+    assert r.reprostim_offset is None
+    assert r.reprostim_buffer_before is None
+    assert r.reprostim_buffer_after is None
+
+
+def test_parse_scans_model_reprostim_cols_not_in_extra(tmp_path):
+    """reprostim_* columns are excluded from ScanRecord.extra."""
+    tsv = tmp_path / "sub-qa_ses-20250814_scans.tsv"
+    _write_scans_tsv(
+        tsv,
+        [
+            "func/bold.nii.gz\t2025-08-14T15:06:09.742500\tn/a\tabc123"
+            "\tvideo1.mkv\t560.3\t10.0\t10.0"
+        ],
+        "filename\tacq_time\toperator\trandstr"
+        "\treprostim_path\treprostim_offset\treprostim_buffer_before\t"
+        "reprostim_buffer_after",
+    )
+    model = _parse_scans_model(str(tsv))
+    for col in _REPROSTIM_COLS:
+        assert col not in model.records[0].extra
+
+
+# ===========================================================================
+# _save_scans_model
+# ===========================================================================
+
+
+def _make_scans_model(tmp_path: Path, extra_header="", extra_values="") -> ScansModel:
+    """Write a minimal _scans.tsv and parse it into a ScansModel."""
+    header = "filename\tacq_time\toperator" + extra_header
+    row = "func/bold.nii.gz\t2025-08-14T15:06:09.742500\tn/a" + extra_values
+    tsv = tmp_path / "sub-qa_ses-20250814_scans.tsv"
+    _write_scans_tsv(tsv, [row], header)
+    return _parse_scans_model(str(tsv))
+
+
+def test_save_scans_model_appends_reprostim_cols(tmp_path):
+    """reprostim_* columns are appended to the right of existing columns."""
+    model = _make_scans_model(tmp_path)
+    model.records[0].reprostim_path = "video1.mkv"
+    model.records[0].reprostim_offset = 560.3
+    model.records[0].reprostim_buffer_before = 10.0
+    model.records[0].reprostim_buffer_after = 10.0
+
+    _save_scans_model(model)
+
+    saved = _parse_scans_model(model.path)
+    r = saved.records[0]
+    assert r.reprostim_path == "video1.mkv"
+    assert r.reprostim_offset == 560.3
+    assert r.reprostim_buffer_before == 10.0
+    assert r.reprostim_buffer_after == 10.0
+
+
+def test_save_scans_model_none_written_as_na(tmp_path):
+    """None reprostim_* fields are written as 'n/a' and round-trip back to None."""
+    model = _make_scans_model(tmp_path)
+    # Leave all reprostim_* fields as None (default).
+    _save_scans_model(model)
+
+    content = Path(model.path).read_text(encoding="utf-8")
+    for col in _REPROSTIM_COLS:
+        assert col in content
+
+    saved = _parse_scans_model(model.path)
+    r = saved.records[0]
+    assert r.reprostim_path is None
+    assert r.reprostim_offset is None
+    assert r.reprostim_buffer_before is None
+    assert r.reprostim_buffer_after is None
+
+
+def test_save_scans_model_preserves_existing_columns(tmp_path):
+    """Existing columns (operator, randstr) are preserved after save."""
+    model = _make_scans_model(
+        tmp_path, extra_header="\trandstr", extra_values="\tabc123"
+    )
+    _save_scans_model(model)
+
+    saved = _parse_scans_model(model.path)
+    assert saved.records[0].extra.get("operator") == "n/a"
+    assert saved.records[0].extra.get("randstr") == "abc123"
+
+
+def test_save_scans_model_reprostim_cols_order(tmp_path):
+    """reprostim_* columns appear in _REPROSTIM_COLS order after existing columns."""
+    model = _make_scans_model(tmp_path)
+    _save_scans_model(model)
+
+    import csv as _csv
+
+    with open(model.path, newline="", encoding="utf-8") as f:
+        fieldnames = list(_csv.DictReader(f, delimiter="\t").fieldnames or [])
+
+    reprostim_positions = [fieldnames.index(c) for c in _REPROSTIM_COLS]
+    assert reprostim_positions == sorted(
+        reprostim_positions
+    ), "reprostim_* columns are not in the expected order"
+    # All reprostim_* cols appear after all non-reprostim cols.
+    non_reprostim = [i for i, f in enumerate(fieldnames) if f not in _REPROSTIM_COLS]
+    assert max(non_reprostim) < min(reprostim_positions)
+
+
+def test_save_scans_model_unix_line_endings(tmp_path):
+    """Saved file uses Unix line endings (LF only, no CR)."""
+    model = _make_scans_model(tmp_path)
+    _save_scans_model(model)
+    raw = Path(model.path).read_bytes()
+    assert b"\r" not in raw
+
+
+def test_save_scans_model_idempotent(tmp_path):
+    """Saving twice does not duplicate reprostim_* columns."""
+    model = _make_scans_model(tmp_path)
+    model.records[0].reprostim_path = "video1.mkv"
+    _save_scans_model(model)
+
+    model2 = _parse_scans_model(model.path)
+    model2.records[0].reprostim_path = "video1.mkv"
+    _save_scans_model(model2)
+
+    import csv as _csv
+
+    with open(model.path, newline="", encoding="utf-8") as f:
+        fieldnames = list(_csv.DictReader(f, delimiter="\t").fieldnames or [])
+
+    for col in _REPROSTIM_COLS:
+        assert fieldnames.count(col) == 1, f"Column '{col}' duplicated after two saves"

--- a/tests/qr/test_split_video.py
+++ b/tests/qr/test_split_video.py
@@ -891,7 +891,7 @@ def test_do_main_specs_single_spec_output_used_as_is(mock_csd, mock_sv):
     mock_csd.return_value = _make_sd()
     mock_sv.return_value = _make_sr_ms(output_path="/out/clip.mkv")
 
-    failures = _do_main_specs(
+    failures, results = _do_main_specs(
         specs=("2024-02-02T17:30:00/PT3M",),
         input_path="/fake/video.mkv",
         output_template="/out/clip.mkv",
@@ -905,6 +905,7 @@ def test_do_main_specs_single_spec_output_used_as_is(mock_csd, mock_sv):
     )
 
     assert failures == 0
+    assert len(results) == 1
     mock_sv.assert_called_once()
     # Positional arg[1] is out_path; no tokens → unchanged
     assert mock_sv.call_args[0][1] == "/out/clip.mkv"
@@ -920,7 +921,7 @@ def test_do_main_specs_multiple_specs_unique_output_files(mock_csd, mock_sv):
         _make_sr_ms("/out/clip_002.mkv"),
     ]
 
-    failures = _do_main_specs(
+    failures, results = _do_main_specs(
         specs=("2024-02-02T17:30:00/PT3M", "2024-02-02T17:40:00/PT3M"),
         input_path="/fake/video.mkv",
         output_template="/out/clip_{n}.mkv",
@@ -934,6 +935,7 @@ def test_do_main_specs_multiple_specs_unique_output_files(mock_csd, mock_sv):
     )
 
     assert failures == 0
+    assert len(results) == 2
     assert mock_sv.call_count == 2
     out_paths = [c[0][1] for c in mock_sv.call_args_list]
     assert "/out/clip_001.mkv" in out_paths
@@ -965,7 +967,7 @@ def test_do_main_specs_per_spec_failure_continues_processing(mock_csd, mock_sv):
     mock_csd.side_effect = [ValueError("simulated failure"), _make_sd(17, 40)]
     mock_sv.return_value = _make_sr_ms("/out/clip_002.mkv")
 
-    failures = _do_main_specs(
+    failures, results = _do_main_specs(
         specs=("2024-02-02T17:30:00/PT3M", "2024-02-02T17:40:00/PT3M"),
         input_path="/fake/video.mkv",
         output_template="/out/clip_{n}.mkv",
@@ -979,6 +981,7 @@ def test_do_main_specs_per_spec_failure_continues_processing(mock_csd, mock_sv):
     )
 
     assert failures == 1
+    assert len(results) == 1
     # Second spec still ran despite first failure
     mock_sv.assert_called_once()
 
@@ -1073,7 +1076,7 @@ def test_cli_neither_spec_nor_start_raises(input_video):
 
 def test_cli_lock_yes_passed_to_do_main(input_video):
     """--lock yes results in lock=True passed to do_main."""
-    with patch("reprostim.qr.split_video.do_main", return_value=0) as mock_dm:
+    with patch("reprostim.qr.split_video.do_main", return_value=(0, [])) as mock_dm:
         CliRunner().invoke(
             split_video,
             [
@@ -1093,7 +1096,7 @@ def test_cli_lock_yes_passed_to_do_main(input_video):
 
 def test_cli_lock_no_passed_to_do_main(input_video):
     """--lock no results in lock=False passed to do_main."""
-    with patch("reprostim.qr.split_video.do_main", return_value=0) as mock_dm:
+    with patch("reprostim.qr.split_video.do_main", return_value=(0, [])) as mock_dm:
         CliRunner().invoke(
             split_video,
             [
@@ -1113,7 +1116,7 @@ def test_cli_lock_no_passed_to_do_main(input_video):
 
 def test_cli_raw_flag_passed_to_do_main(input_video):
     """--raw flag results in raw=True passed to do_main."""
-    with patch("reprostim.qr.split_video.do_main", return_value=0) as mock_dm:
+    with patch("reprostim.qr.split_video.do_main", return_value=(0, [])) as mock_dm:
         CliRunner().invoke(
             split_video,
             [
@@ -1132,7 +1135,7 @@ def test_cli_raw_flag_passed_to_do_main(input_video):
 
 def test_cli_sidecar_format_bids_passed_to_do_main(input_video):
     """--sidecar-format bids passes sidecar_format='bids' to do_main."""
-    with patch("reprostim.qr.split_video.do_main", return_value=0) as mock_dm:
+    with patch("reprostim.qr.split_video.do_main", return_value=(0, [])) as mock_dm:
         CliRunner().invoke(
             split_video,
             [
@@ -1152,7 +1155,7 @@ def test_cli_sidecar_format_bids_passed_to_do_main(input_video):
 
 def test_cli_sidecar_format_raw_passed_to_do_main(input_video):
     """--sidecar-format raw passes sidecar_format='raw' to do_main."""
-    with patch("reprostim.qr.split_video.do_main", return_value=0) as mock_dm:
+    with patch("reprostim.qr.split_video.do_main", return_value=(0, [])) as mock_dm:
         CliRunner().invoke(
             split_video,
             [
@@ -1294,27 +1297,33 @@ def test_split_video_resolution_none_gives_na_dimensions():
 
 def test_do_main_start_duration_builds_spec():
     """do_main with start_time+duration builds a START/DURATION spec."""
-    with patch("reprostim.qr.split_video._do_main_specs", return_value=0) as mock_dms:
-        result = do_main(
+    with patch(
+        "reprostim.qr.split_video._do_main_specs", return_value=(0, [])
+    ) as mock_dms:
+        ret, results = do_main(
             input_path="/fake/video.mkv",
             output_path="/out/clip.mkv",
             start_time="2024-02-02T17:30:00",
             duration="PT3M",
         )
-    assert result == 0
+    assert ret == 0
+    assert results == []
     assert mock_dms.call_args.kwargs["specs"] == ("2024-02-02T17:30:00/PT3M",)
 
 
 def test_do_main_start_end_builds_spec():
     """do_main with start_time+end_time builds a START//END spec."""
-    with patch("reprostim.qr.split_video._do_main_specs", return_value=0) as mock_dms:
-        result = do_main(
+    with patch(
+        "reprostim.qr.split_video._do_main_specs", return_value=(0, [])
+    ) as mock_dms:
+        ret, results = do_main(
             input_path="/fake/video.mkv",
             output_path="/out/clip.mkv",
             start_time="2024-02-02T17:30:00",
             end_time="2024-02-02T17:33:00",
         )
-    assert result == 0
+    assert ret == 0
+    assert results == []
     assert mock_dms.call_args.kwargs["specs"] == (
         "2024-02-02T17:30:00//2024-02-02T17:33:00",
     )
@@ -1322,23 +1331,27 @@ def test_do_main_start_end_builds_spec():
 
 def test_do_main_specs_provided_directly():
     """do_main with specs tuple passes them straight to _do_main_specs."""
-    with patch("reprostim.qr.split_video._do_main_specs", return_value=0) as mock_dms:
-        result = do_main(
+    with patch(
+        "reprostim.qr.split_video._do_main_specs", return_value=(0, [])
+    ) as mock_dms:
+        ret, results = do_main(
             input_path="/fake/video.mkv",
             output_path="/out/clip_{n}.mkv",
             specs=("2024-02-02T17:30:00/PT3M",),
         )
-    assert result == 0
+    assert ret == 0
+    assert results == []
     assert mock_dms.call_args.kwargs["specs"] == ("2024-02-02T17:30:00/PT3M",)
 
 
 def test_do_main_neither_spec_nor_start_returns_1():
     """do_main with no spec and no start_time returns exit code 1."""
-    result = do_main(
+    ret, results = do_main(
         input_path="/fake/video.mkv",
         output_path="/out/clip.mkv",
     )
-    assert result == 1
+    assert ret == 1
+    assert results == []
 
 
 def test_do_main_value_error_from_specs_returns_5():
@@ -1348,20 +1361,23 @@ def test_do_main_value_error_from_specs_returns_5():
         "reprostim.qr.split_video._do_main_specs",
         side_effect=ValueError("bad template"),
     ):
-        result = do_main(
+        ret, results = do_main(
             input_path="/fake/video.mkv",
             output_path="/out/clip.mkv",
             specs=("2024-02-02T17:30:00/PT3M",),
             out_func=messages.append,
         )
-    assert result == 5
+    assert ret == 5
+    assert results == []
     assert any("ERROR" in m for m in messages)
 
 
 def test_do_main_sidecar_metadata_passed_to_do_main_specs():
     """do_main forwards sidecar_metadata to _do_main_specs."""
     meta = {"TaskName": "nback"}
-    with patch("reprostim.qr.split_video._do_main_specs", return_value=0) as mock_dms:
+    with patch(
+        "reprostim.qr.split_video._do_main_specs", return_value=(0, [])
+    ) as mock_dms:
         do_main(
             input_path="/fake/video.mkv",
             output_path="/out/clip.mkv",
@@ -1385,7 +1401,7 @@ def test_do_main_specs_sd_success_false_counts_as_failure(mock_csd, mock_sv):
     sd.success = False
     mock_csd.return_value = sd
 
-    failures = _do_main_specs(
+    failures, results = _do_main_specs(
         specs=("2024-02-02T17:30:00/PT3M",),
         input_path="/fake/video.mkv",
         output_template="/out/clip.mkv",
@@ -1399,6 +1415,7 @@ def test_do_main_specs_sd_success_false_counts_as_failure(mock_csd, mock_sv):
     )
 
     assert failures == 1
+    assert results == []
     mock_sv.assert_not_called()
 
 
@@ -1411,7 +1428,7 @@ def test_do_main_specs_split_video_failure_counts(mock_csd, mock_sv):
     sr.success = False
     mock_sv.return_value = sr
 
-    failures = _do_main_specs(
+    failures, results = _do_main_specs(
         specs=("2024-02-02T17:30:00/PT3M",),
         input_path="/fake/video.mkv",
         output_template="/out/clip.mkv",
@@ -1425,6 +1442,7 @@ def test_do_main_specs_split_video_failure_counts(mock_csd, mock_sv):
     )
 
     assert failures == 1
+    assert results == []
 
 
 @patch("reprostim.qr.split_video._split_video")
@@ -1514,7 +1532,7 @@ def test_cli_start_without_duration_or_end_raises(input_video):
 
 def test_cli_sidecar_json_auto_passed_to_do_main(input_video):
     """--sidecar-json auto passes sidecar_json='auto' to do_main."""
-    with patch("reprostim.qr.split_video.do_main", return_value=0) as mock_dm:
+    with patch("reprostim.qr.split_video.do_main", return_value=(0, [])) as mock_dm:
         CliRunner().invoke(
             split_video,
             [
@@ -1534,7 +1552,7 @@ def test_cli_sidecar_json_auto_passed_to_do_main(input_video):
 
 def test_cli_sidecar_json_explicit_path_passed_to_do_main(input_video):
     """Explicit --sidecar-json path is forwarded unchanged to do_main."""
-    with patch("reprostim.qr.split_video.do_main", return_value=0) as mock_dm:
+    with patch("reprostim.qr.split_video.do_main", return_value=(0, [])) as mock_dm:
         CliRunner().invoke(
             split_video,
             [
@@ -1554,7 +1572,7 @@ def test_cli_sidecar_json_explicit_path_passed_to_do_main(input_video):
 
 def test_cli_verbose_emits_completed_message(input_video):
     """--verbose causes the 'completed' elapsed-time line to be echoed."""
-    with patch("reprostim.qr.split_video.do_main", return_value=0):
+    with patch("reprostim.qr.split_video.do_main", return_value=(0, [])):
         result = CliRunner().invoke(
             split_video,
             [


### PR DESCRIPTION
  Add `reprostim_*` columns to `_scans.tsv` after each `bids-inject` run, save the source video path and exact buffer timing info used for each injection.

In continuation to:
- #251
- #14 

**Tasks:**
  - [x] `bids-inject` writes new columns back to `_scans.tsv` after processing: 
    - `reprostim_path`
    - `reprostim_offset`
    - `reprostim_buffer_before`
    - `reprostim_buffer_after`
  - [x] On successful injection, columns are populated from the actual split result; on failure or skip, n/a is written (clearing any stale values from prior runs).
  - [x] `--dry-run` mode leaves `_scans.tsv` untouched
  - [x] `split-video` Python API now returns the list of `SplitResult` objects alongside the exit code, enabling callers like `bids-inject` to consume actual buffer measurements without re-parsing files.
  - [x] Updated unit and integration tests for new functionality.
  - [x] Manually tested on typhon for `sub-qa/ses-20250814` in the `~/branches/QA-reprostim`  dataset.

