### PR TITLE
Update `video-audit` to handle non-existent paths gracefully

### DIFF
--- a/.ai/spec-video-audit.md
+++ b/.ai/spec-video-audit.md
@@ -28,7 +28,7 @@ reprostim video-audit [OPTIONS] [PATHS]...
 
 | Argument  | Description                                                                     |
 |-----------|---------------------------------------------------------------------------------|
-| `PATHS`   | One or more paths to video files (`.mkv`, `.mp4`, `.avi`) or directories. Required. |
+| `PATHS`   | One or more paths to video files (`.mkv`, `.mp4`, `.avi`) or directories. Required. For `rerun-for-na` and `reset-to-na` modes, paths are used as filters against existing TSV records and need not exist on disk. |
 
 ### Options
 
@@ -157,7 +157,7 @@ Tab-separated file. One row per video file, columns defined by `VaRecord`:
 | `audio_dur` | Audio stream duration (seconds) |
 | `duration` | Best-available duration (seconds) |
 | `duration_h` | Human-readable duration (`HH:MM:SS.mmm`) |
-| `no_signal_frames` | No-signal percentage from `detect-noscreen`, or `n/a` |
+| `no_signal_frames` | No-signal percentage from `detect-noscreen`, `n/a` if not yet processed, or `-3` if video file not found on disk |
 | `qr_records_number` | QR record count from `qr-parse`, or `n/a` |
 | `file_log_coherent` | Whether video/audio metadata is internally consistent |
 | `no_signal_updated_on` | Timestamp of last nosignal update |
@@ -166,9 +166,15 @@ Tab-separated file. One row per video file, columns defined by `VaRecord`:
 
 Sentinel values for `qr_records_number`:
 - `n/a` — not yet processed
+- `-3` — video file not found on disk (set by both `nosignal` and `qr` sources)
 - `-2` — ffmpeg conversion started but qr-parse not yet invoked
 - `-1` — qr-parse completed but no `ParseSummary` record found in output
 - `≥ 0` — actual QR record count
+
+Sentinel values for `no_signal_frames`:
+- `n/a` — not yet processed
+- `-3` — video file not found on disk
+- `≥ 0.0` — percentage of no-signal frames from `detect-noscreen`
 
 ---
 

--- a/.ai/task-video-audit.md
+++ b/.ai/task-video-audit.md
@@ -59,6 +59,14 @@ Tracks implementation progress against [spec-video-audit.md](spec-video-audit.md
 - [x] Pass `qr_opts` to qr-parse via `VaContext`
 - [x] Accept `--qr-opts` override from CLI (shlex-parsed)
 
+### Non-existing video handling (issue #253)
+- [x] CLI `PATHS` argument accepts non-existent paths (removed `exists=True`)
+- [x] CLI handler: for `rerun-for-na`/`reset-to-na`, non-existent paths emit warning instead of error
+- [x] `do_main`: for `rerun-for-na`/`reset-to-na`, non-existent paths emit warning and continue instead of returning 1
+- [x] `do_ext`: non-existent paths added to filter sets by extension heuristic (`.mkv`/`.mp4`/`.avi` → `path_files`, otherwise → `path_dirs`)
+- [x] `run_ext_nosignal`: video file not on disk → set `no_signal_frames = "-3"`, update timestamp, increment counter
+- [x] `run_ext_qr`: video file not on disk → set `qr_records_number = "-3"`, update timestamp, increment counter
+
 ### Operation modes (`VaMode`)
 - [x] `full` — regenerate all records from scratch
 - [x] `incremental` — process only new files, merge into existing TSV
@@ -246,6 +254,8 @@ Test file location: `tests/qr/test_video_audit.py`
 - [x] `run_ext_nosignal` — `rerun-for-na` + non-`n/a` → skipped
 - [x] `run_ext_nosignal` — `max_counter` reached → returns `vr` unchanged
 - [x] `run_ext_nosignal` — `path_mask` no-match → returns `vr` unchanged
+- [x] `run_ext_nosignal` — video file not on disk → `no_signal_frames = "-3"`, timestamp updated
+- [x] `run_ext_nosignal` — video file not on disk in `rerun-for-na` → sentinel `-3` breaks retry loop
 - [x] `run_ext_nosignal` — subprocess success with `nosignal_rate` → percentage stored
 - [x] `run_ext_nosignal` — subprocess success without `nosignal_rate` key → `"0.0"`
 - [x] `run_ext_nosignal` — `CalledProcessError` → `no_signal_frames` unchanged
@@ -255,6 +265,8 @@ Test file location: `tests/qr/test_video_audit.py`
 - [x] `run_ext_qr` — `rerun-for-na` + non-`n/a` → skipped
 - [x] `run_ext_qr` — `max_counter` reached → returns `vr` unchanged
 - [x] `run_ext_qr` — `path_mask` no-match → returns `vr` unchanged
+- [x] `run_ext_qr` — video file not on disk → `qr_records_number = "-3"`, timestamp updated
+- [x] `run_ext_qr` — video file not on disk in `rerun-for-na` → sentinel `-3` breaks retry loop
 - [x] `run_ext_qr` — subprocess success with `ParseSummary` → `qr_count` stored
 - [x] `run_ext_qr` — ffmpeg `CalledProcessError` → `qr_records_number` = `"-2"`
 - [x] `run_ext_qr` — no `ParseSummary` in output → `qr_records_number` = `"-1"`
@@ -267,12 +279,17 @@ Test file location: `tests/qr/test_video_audit.py`
 - [x] Record path matches explicit file → processed
 - [x] Record path starts with directory → processed
 - [x] Record not matching filter → yielded unchanged
+- [x] Non-existent `.mkv` path → added to `path_files` filter (matches record by string)
+- [x] Non-existent non-video path → added to `path_dirs` filter (matches record by prefix)
 
 #### `do_main`
 - [x] Invalid path → returns `1`
 - [x] Incremental mode, no existing TSV → creates new TSV, returns `0`
 - [x] Incremental mode, existing TSV → loads existing, merges, saves
 - [x] `rerun-for-na` mode → calls `do_ext` on existing records
+- [x] `rerun-for-na` mode + non-existent path → warns and returns `0` (not `1`)
+- [x] `reset-to-na` mode + non-existent path → warns and returns `0` (not `1`)
+- [x] `incremental` mode + non-existent path → returns `1` (unchanged behavior)
 - [x] `nosignal_opts` / `qr_opts` strings shlex-parsed into `VaContext`
 - [x] `ffprobe` missing → prints error message, still returns `0`
 - [x] `verbose=True` → records printed as JSON via `out_func`
@@ -304,6 +321,8 @@ Test file location: `tests/qr/test_video_audit.py`
 |---|---|---|
 | `qr/video_audit.py` — overall | ≥ 80% | 93% |
 | `cli/cmd_video_audit.py` | ≥ 80% | 94% |
+
+_Updated for issue #253: 12 new tests added (164 total), covering non-existing video handling for all 3 audit sources and CLI layer._
 
 ---
 

--- a/src/reprostim/cli/cmd_video_audit.py
+++ b/src/reprostim/cli/cmd_video_audit.py
@@ -37,7 +37,7 @@ def _apply_config(ctx, config: dict, param_name: str, current_val):
 @click.argument(
     "paths",
     nargs=-1,  # accept 1 or more arguments
-    type=click.Path(exists=True, dir_okay=True, file_okay=True),
+    type=click.Path(exists=False, dir_okay=True, file_okay=True),
 )
 @click.option(
     "-m",
@@ -217,8 +217,14 @@ def video_audit(
 
     for path in paths:
         if not os.path.exists(path):
-            logger.error(f"Path does not exist: {path}")
-            return 1
+            if mode in ("rerun-for-na", "reset-to-na"):
+                logger.warning(
+                    f"Path does not exist: {path}"
+                    f" (used as filter for existing TSV records)"
+                )
+            else:
+                logger.error(f"Path does not exist: {path}")
+                return 1
 
     do_main(
         list(paths),

--- a/src/reprostim/cli/cmd_video_audit.py
+++ b/src/reprostim/cli/cmd_video_audit.py
@@ -224,9 +224,9 @@ def video_audit(
                 )
             else:
                 logger.error(f"Path does not exist: {path}")
-                return 1
+                ctx.exit(1)
 
-    do_main(
+    rv = do_main(
         list(paths),
         output,
         recursive,
@@ -239,4 +239,5 @@ def video_audit(
         nosignal_opts=nosignal_opts,
         qr_opts=qr_opts,
     )
-    return 0
+    if rv:
+        ctx.exit(rv)

--- a/src/reprostim/qr/video_audit.py
+++ b/src/reprostim/qr/video_audit.py
@@ -1087,6 +1087,17 @@ def run_ext_nosignal(ctx: VaContext, vr: VaRecord) -> VaRecord:
             logger.debug("Skipping nosignal source as per context (not n/a)")
             return vr
 
+    # check video file exists on disk before running external tool
+    if not os.path.exists(vr.path):
+        logger.warning(
+            f"Video file not found on disk, " f"setting no_signal_frames=-3: {vr.path}"
+        )
+        vr.no_signal_frames = "-3"
+        _set_updated(ctx, vr, field="no_signal_updated_on")
+        ctx.c_nosignal += 1
+        logger.debug(f"c_nosignal -> {ctx.c_nosignal}")
+        return vr
+
     # make sure data and logs dirs exist
     os.makedirs(ctx.nosignal_data_dir, exist_ok=True)
     os.makedirs(ctx.nosignal_log_dir, exist_ok=True)
@@ -1204,6 +1215,17 @@ def run_ext_qr(ctx: VaContext, vr: VaRecord) -> VaRecord:
         if vr.qr_records_number != "n/a":
             logger.debug("Skipping qr source as per context (not n/a)")
             return vr
+
+    # check video file exists on disk before running external tool
+    if not os.path.exists(vr.path):
+        logger.warning(
+            f"Video file not found on disk, " f"setting qr_records_number=-3: {vr.path}"
+        )
+        vr.qr_records_number = "-3"
+        _set_updated(ctx, vr, field="qr_updated_on")
+        ctx.c_qr += 1
+        logger.debug(f"c_qr -> {ctx.c_qr}")
+        return vr
 
     # make sure data and logs dirs exist
     os.makedirs(ctx.qr_data_dir, exist_ok=True)
@@ -1378,7 +1400,20 @@ def do_ext(
             elif os.path.isdir(path):
                 path_dirs.add(_normalize_path(path))
         else:
-            logger.error(f"Path does not exist: {path}")
+            # Path not on disk — classify by extension so record paths can
+            # still be matched by string comparison (e.g. rerun-for-na on a
+            # video that was deleted or moved after being added to videos.tsv)
+            p = _normalize_path(path)
+            if path.lower().endswith((".mkv", ".mp4", ".avi")):
+                logger.warning(
+                    f"Video file not found on disk, used as path filter: {path}"
+                )
+                path_files.add(p)
+            else:
+                logger.warning(
+                    f"Directory not found on disk, used as path filter: {path}"
+                )
+                path_dirs.add(p)
 
     for rec in recs:
         # filter by paths when specified
@@ -1640,8 +1675,14 @@ def do_main(
     # double validate each path is valid and exists
     for path in paths:
         if not os.path.exists(path):
-            logger.error(f"Path does not exist: {path}")
-            return 1
+            if mode in {VaMode.RERUN_FOR_NA, VaMode.RESET_TO_NA}:
+                logger.warning(
+                    f"Path does not exist: {path}"
+                    f" (used as filter for existing TSV records)"
+                )
+            else:
+                logger.error(f"Path does not exist: {path}")
+                return 1
 
     if not check_ffprobe():
         out_func(

--- a/tests/qr/test_video_audit.py
+++ b/tests/qr/test_video_audit.py
@@ -135,7 +135,7 @@ def test_help_renders():
 def test_nosignal_opts_forwarded(tmp_mkv):
     """-n / --nosignal-opts value is forwarded to do_main as nosignal_opts kwarg."""
     opts = "--number-of-checks 200 --threshold 0.9"
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["-n", opts, tmp_mkv])
     assert result.exit_code == 0
     assert mock_do_main.call_args.kwargs["nosignal_opts"] == opts
@@ -145,7 +145,7 @@ def test_nosignal_opts_short_form_forwarded(tmp_mkv):
     """Short form -n is accepted and forwards the value identically
     to --nosignal-opts."""
     opts = "--number-of-checks 50"
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["--nosignal-opts", opts, tmp_mkv])
     assert result.exit_code == 0
     assert mock_do_main.call_args.kwargs["nosignal_opts"] == opts
@@ -154,7 +154,7 @@ def test_nosignal_opts_short_form_forwarded(tmp_mkv):
 def test_nosignal_opts_default_is_none(tmp_mkv):
     """Omitting --nosignal-opts passes nosignal_opts=None so VaContext uses
     built-in defaults."""
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke([tmp_mkv])
     assert result.exit_code == 0
     assert mock_do_main.call_args.kwargs["nosignal_opts"] is None
@@ -168,7 +168,7 @@ def test_nosignal_opts_default_is_none(tmp_mkv):
 def test_qr_opts_forwarded(tmp_mkv):
     """-q / --qr-opts value is forwarded to do_main as qr_opts kwarg."""
     opts = "--skip 2 --std-threshold 15"
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["-q", opts, tmp_mkv])
     assert result.exit_code == 0
     assert mock_do_main.call_args.kwargs["qr_opts"] == opts
@@ -177,7 +177,7 @@ def test_qr_opts_forwarded(tmp_mkv):
 def test_qr_opts_short_form_forwarded(tmp_mkv):
     """Short form -q is accepted and forwards the value identically to --qr-opts."""
     opts = "--skip 4"
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["--qr-opts", opts, tmp_mkv])
     assert result.exit_code == 0
     assert mock_do_main.call_args.kwargs["qr_opts"] == opts
@@ -185,7 +185,7 @@ def test_qr_opts_short_form_forwarded(tmp_mkv):
 
 def test_qr_opts_default_is_none(tmp_mkv):
     """Omitting --qr-opts passes qr_opts=None so no extra options are forwarded."""
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke([tmp_mkv])
     assert result.exit_code == 0
     assert mock_do_main.call_args.kwargs["qr_opts"] is None
@@ -200,7 +200,7 @@ def test_config_nosignal_opts(tmp_path, tmp_mkv):
     """nosignal-opts from config file is forwarded to do_main as nosignal_opts."""
     cfg = tmp_path / "config.yaml"
     cfg.write_text("nosignal-opts: '--number-of-checks 300 --threshold 0.8'\n")
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["-c", str(cfg), tmp_mkv])
     assert result.exit_code == 0
     assert (
@@ -213,7 +213,7 @@ def test_config_qr_opts(tmp_path, tmp_mkv):
     """qr-opts from config file is forwarded to do_main as qr_opts."""
     cfg = tmp_path / "config.yaml"
     cfg.write_text("qr-opts: '--skip 3 --std-threshold 20'\n")
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["-c", str(cfg), tmp_mkv])
     assert result.exit_code == 0
     assert mock_do_main.call_args.kwargs["qr_opts"] == "--skip 3 --std-threshold 20"
@@ -224,7 +224,7 @@ def test_config_cli_overrides_nosignal_opts(tmp_path, tmp_mkv):
     cfg = tmp_path / "config.yaml"
     cfg.write_text("nosignal-opts: '--number-of-checks 300'\n")
     cli_opts = "--number-of-checks 999"
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["-c", str(cfg), "-n", cli_opts, tmp_mkv])
     assert result.exit_code == 0
     assert mock_do_main.call_args.kwargs["nosignal_opts"] == cli_opts
@@ -235,7 +235,7 @@ def test_config_cli_overrides_qr_opts(tmp_path, tmp_mkv):
     cfg = tmp_path / "config.yaml"
     cfg.write_text("qr-opts: '--skip 3'\n")
     cli_opts = "--skip 99"
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["-c", str(cfg), "-q", cli_opts, tmp_mkv])
     assert result.exit_code == 0
     assert mock_do_main.call_args.kwargs["qr_opts"] == cli_opts
@@ -245,7 +245,7 @@ def test_config_other_keys(tmp_path, tmp_mkv):
     """mode, recursive, and max-files from config are passed correctly to do_main."""
     cfg = tmp_path / "config.yaml"
     cfg.write_text("mode: full\nrecursive: true\nmax-files: 5\n")
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["-c", str(cfg), tmp_mkv])
     assert result.exit_code == 0
     args = mock_do_main.call_args.args
@@ -258,7 +258,7 @@ def test_config_audit_src_list(tmp_path, tmp_mkv):
     """audit-src list in config is converted to a set of VaSource values."""
     cfg = tmp_path / "config.yaml"
     cfg.write_text("audit-src:\n  - internal\n  - qr\n")
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["-c", str(cfg), tmp_mkv])
     assert result.exit_code == 0
     va_src = mock_do_main.call_args.args[4]
@@ -274,7 +274,7 @@ def test_config_audit_src_scalar_string(tmp_path, tmp_mkv):
     """Config audit-src as a scalar string is wrapped into a single-element tuple."""
     cfg = tmp_path / "config.yaml"
     cfg.write_text("audit-src: qr\n")
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["-c", str(cfg), tmp_mkv])
     assert result.exit_code == 0
     va_src = mock_do_main.call_args.args[4]
@@ -283,7 +283,7 @@ def test_config_audit_src_scalar_string(tmp_path, tmp_mkv):
 
 def test_mode_full_passed_to_do_main(tmp_mkv):
     """--mode full passes VaMode.FULL as the mode positional arg to do_main."""
-    with patch("reprostim.qr.video_audit.do_main") as mock_do_main:
+    with patch("reprostim.qr.video_audit.do_main", return_value=0) as mock_do_main:
         result = _invoke(["--mode", "full", tmp_mkv])
     assert result.exit_code == 0
     assert mock_do_main.call_args.args[3] == VaMode.FULL

--- a/tests/qr/test_video_audit.py
+++ b/tests/qr/test_video_audit.py
@@ -1731,3 +1731,143 @@ def test_do_main_incremental_merges_existing(tmp_path):
     assert rc == 0
     names = {r.name for r in _load_tsv(tsv)}
     assert "old.mkv" in names and "new.mkv" in names
+
+
+# ===========================================================================
+# Issue #253 — non-existing video handling
+# ===========================================================================
+
+
+def test_run_ext_nosignal_file_not_found():
+    """Non-existent video file → no_signal_frames set to '-3'
+    (file-not-found sentinel)."""
+    vr = _rec(name="ghost.mkv", path="/nonexistent/ghost.mkv", no_signal_frames="n/a")
+    ctx = _ctx(source={VaSource.NOSIGNAL}, mode=VaMode.RERUN_FOR_NA)
+    result = run_ext_nosignal(ctx, vr)
+    assert result.no_signal_frames == "-3"
+    assert result.no_signal_updated_on != "n/a"
+    assert ctx.c_nosignal == 1
+
+
+def test_run_ext_nosignal_file_not_found_incremental():
+    """Non-existent video file in incremental mode → no_signal_frames set to '-3'."""
+    vr = _rec(name="ghost.mkv", path="/nonexistent/ghost.mkv", no_signal_frames="n/a")
+    ctx = _ctx(source={VaSource.NOSIGNAL}, mode=VaMode.INCREMENTAL)
+    result = run_ext_nosignal(ctx, vr)
+    assert result.no_signal_frames == "-3"
+    assert ctx.c_nosignal == 1
+
+
+def test_run_ext_qr_file_not_found():
+    """Non-existent video file → qr_records_number set to '-3'
+    (file-not-found sentinel)."""
+    vr = _rec(name="ghost.mkv", path="/nonexistent/ghost.mkv", qr_records_number="n/a")
+    ctx = _ctx(source={VaSource.QR}, mode=VaMode.RERUN_FOR_NA)
+    result = run_ext_qr(ctx, vr)
+    assert result.qr_records_number == "-3"
+    assert result.qr_updated_on != "n/a"
+    assert ctx.c_qr == 1
+
+
+def test_run_ext_qr_file_not_found_incremental():
+    """Non-existent video file in incremental mode → qr_records_number set to '-3'."""
+    vr = _rec(name="ghost.mkv", path="/nonexistent/ghost.mkv", qr_records_number="n/a")
+    ctx = _ctx(source={VaSource.QR}, mode=VaMode.INCREMENTAL)
+    result = run_ext_qr(ctx, vr)
+    assert result.qr_records_number == "-3"
+    assert ctx.c_qr == 1
+
+
+def test_run_ext_nosignal_rerun_for_na_already_set_skips():
+    """rerun-for-na skips records where no_signal_frames is already non-n/a ('-3')."""
+    vr = _rec(name="ghost.mkv", path="/nonexistent/ghost.mkv", no_signal_frames="-3")
+    ctx = _ctx(source={VaSource.NOSIGNAL}, mode=VaMode.RERUN_FOR_NA)
+    result = run_ext_nosignal(ctx, vr)
+    assert result.no_signal_frames == "-3"
+    assert ctx.c_nosignal == 0
+
+
+def test_run_ext_qr_rerun_for_na_already_set_skips():
+    """rerun-for-na skips records where qr_records_number is already non-n/a ('-3')."""
+    vr = _rec(name="ghost.mkv", path="/nonexistent/ghost.mkv", qr_records_number="-3")
+    ctx = _ctx(source={VaSource.QR}, mode=VaMode.RERUN_FOR_NA)
+    result = run_ext_qr(ctx, vr)
+    assert result.qr_records_number == "-3"
+    assert ctx.c_qr == 0
+
+
+def test_do_ext_filter_by_nonexistent_video_file():
+    """Non-existent .mkv path still matches records in the TSV by string comparison."""
+    ghost_path = "/data/Videos/2025/08/ghost.mkv"
+    vr = _rec(name="ghost.mkv", path=ghost_path)
+    ctx = _ctx(source={VaSource.INTERNAL})
+    with patch("reprostim.qr.video_audit.run_ext_all", return_value=vr) as mock_ext:
+        list(do_ext(ctx, [vr], [ghost_path]))
+    mock_ext.assert_called_once()
+
+
+def test_do_ext_filter_by_nonexistent_directory():
+    """Non-existent directory path is used as a prefix filter for record paths."""
+    ghost_dir = "/data/Videos/2025/08"
+    vr = _rec(name="ghost.mkv", path=f"{ghost_dir}/ghost.mkv")
+    ctx = _ctx(source={VaSource.INTERNAL})
+    with patch("reprostim.qr.video_audit.run_ext_all", return_value=vr) as mock_ext:
+        list(do_ext(ctx, [vr], [ghost_dir]))
+    mock_ext.assert_called_once()
+
+
+def test_do_main_rerun_for_na_nonexistent_path(tmp_path):
+    """do_main with non-existent video path in rerun-for-na mode returns 0 (not 1)."""
+    tsv = str(tmp_path / "videos.tsv")
+    ghost_path = "/nonexistent/ghost.mkv"
+    _save_tsv([_rec(name="ghost.mkv", path=ghost_path, qr_records_number="n/a")], tsv)
+    with patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.check_ffprobe", return_value=True
+    ):
+        rc = do_main(
+            [ghost_path],
+            tsv,
+            mode=VaMode.RERUN_FOR_NA,
+            va_src={VaSource.QR},
+        )
+    assert rc == 0
+
+
+def test_do_main_reset_to_na_nonexistent_path(tmp_path):
+    """do_main with non-existent video path in reset-to-na mode returns 0 (not 1)."""
+    tsv = str(tmp_path / "videos.tsv")
+    ghost_path = "/nonexistent/ghost.mkv"
+    _save_tsv([_rec(name="ghost.mkv", path=ghost_path, qr_records_number="5")], tsv)
+    with patch.dict(os.environ, _ENV), patch(
+        "reprostim.qr.video_audit.check_ffprobe", return_value=True
+    ):
+        rc = do_main(
+            [ghost_path],
+            tsv,
+            mode=VaMode.RESET_TO_NA,
+            va_src={VaSource.QR},
+        )
+    assert rc == 0
+
+
+def test_do_main_incremental_nonexistent_path_returns_one(tmp_path):
+    """do_main with non-existent path in incremental mode still returns 1."""
+    tsv = str(tmp_path / "videos.tsv")
+    with patch.dict(os.environ, _ENV):
+        rc = do_main(["/nonexistent/path"], tsv, mode=VaMode.INCREMENTAL)
+    assert rc == 1
+
+
+def test_cli_rerun_for_na_nonexistent_path(tmp_path):
+    """CLI: non-existent video path with --mode rerun-for-na must not
+    raise Click error."""
+    tsv = str(tmp_path / "videos.tsv")
+    ghost_path = "/nonexistent/ghost.mkv"
+    _save_tsv([_rec(name="ghost.mkv", path=ghost_path)], tsv)
+    with patch("reprostim.qr.video_audit.do_main", return_value=0):
+        result = runner.invoke(
+            video_audit,
+            ["-m", "rerun-for-na", "-o", tsv, ghost_path],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0


### PR DESCRIPTION
**Tasks:**

- [x] Implement logic to handle non-existing videos for external jobs like `qr` or `nosignal`.
- [x] Provide unit tests for new functonality.
- [x] Test manually with local data set on dev machine.

**Note:**
- Double-check and test @ typhon once the next release will be deployed.

Closes #253