### PR TITLE
Add `bids-validator` to `repronim-reprostim` container

### DIFF
--- a/.ai/containers/repronim-reprostim-tasks.md
+++ b/.ai/containers/repronim-reprostim-tasks.md
@@ -4,6 +4,46 @@ Tracks implementation tasks related to `repronim-reprostim` container configurat
 
 ---
 
+## Add `bids-validator` (via `bids-validator-deno` PyPI package) to container
+
+**Goal**: Make the [bids-standard/bids-validator](https://github.com/bids-standard/bids-validator)
+CLI available inside the `repronim-reprostim` container as a raw run mode, same as `rsync`,
+`parallel`, `mediainfo`, etc.
+
+**Approach**: Rather than an `apt`/native install, use the precompiled
+[`bids-validator-deno`](https://pypi.org/project/bids-validator-deno/) PyPI wheel (pinned to
+`3.0.1`). It has no OS-level dependency — its `deno>=2.5.0` requirement resolves to a
+platform-specific `deno` wheel (bundling a real Deno binary for linux amd64), so `pip install`
+inside the PsychoPy venv is sufficient; no `generate_container.sh` apt package list changes were
+needed. Its console-script entry point (`bids-validator-deno`) is not runnable via
+`python3 -m bids_validator_deno` (no `__main__.py`), so it needs its own `/usr/local/bin` wrapper,
+mirroring the existing `reprostim` wrapper, rather than following the `python -m visidata` pattern.
+
+**Affected files**:
+- `containers/repronim-reprostim/setup_container.sh`
+- `containers/repronim-reprostim/run_reprostim_ci.sh`
+- `tools/ci/test_reprostim_container.sh`
+
+### Tasks
+
+- [x] **`setup_container.sh`**: `pip install --no-cache-dir bids-validator-deno==3.0.1` into the
+  PsychoPy venv, alongside `visidata`/`py-spy`.
+- [x] **`setup_container.sh`**: Add a `/usr/local/bin/bids-validator-deno` wrapper script
+  (`#!/bin/sh` + exec venv binary), same pattern as the `reprostim` wrapper.
+- [x] **`run_reprostim_ci.sh`**: Add `bids-validator-deno` to `REPROSTIM_RUN_RAW_MODES` so
+  `REPROSTIM_CONTAINER_RUN_MODE=bids-validator-deno` runs it directly (Docker: cleared
+  entrypoint; Singularity: `singularity exec ... bids-validator-deno`).
+- [x] **`tools/ci/test_reprostim_container.sh`**: Add a `bids-validator-deno --version` smoke
+  test, following the `rsync`/`parallel` test blocks.
+- [ ] **Regenerate and manually verify** `Dockerfile.repronim-reprostim` /
+  `Singularity.repronim-reprostim` via `generate_container.sh`, build the image, and confirm
+  `bids-validator-deno --version` and an actual dataset validation run (e.g.
+  `bids-validator-deno /data/some-bids-dataset`) both work — not yet run against a real build.
+- [ ] Consider documenting the new tool in `containers/repronim-reprostim/README.md` /
+  `DOCKERHUB.md` if/when a "bundled tools" list is added there (none currently exists).
+
+---
+
 ## [Issue #217](https://github.com/ReproNim/reprostim/issues/217): Make `reprostim` the default container entrypoint
 
 **Goal**: `singularity run <container.sif> <args>` (and `docker run <image> <args>`) should

--- a/containers/repronim-reprostim/run_reprostim_ci.sh
+++ b/containers/repronim-reprostim/run_reprostim_ci.sh
@@ -27,7 +27,7 @@ elif [[ "$REPROSTIM_CONTAINER_TYPE" == "singularity" ]]; then
 fi
 
 # Calculate entry point and command to run inside container
-REPROSTIM_RUN_RAW_MODES=(python reprostim-videocapture psychopy ffmpeg ffprobe v4l2-ctl mediainfo parallel rsync)
+REPROSTIM_RUN_RAW_MODES=(python reprostim-videocapture psychopy ffmpeg ffprobe v4l2-ctl mediainfo parallel rsync bids-validator-deno)
 REPROSTIM_CONTAINER_ENTRYPOINT=""
 if [[ " ${REPROSTIM_RUN_RAW_MODES[*]} " == *" $REPROSTIM_CONTAINER_RUN_MODE "* ]]; then
     REPROSTIM_CONTAINER_APP="$REPROSTIM_CONTAINER_RUN_MODE"

--- a/containers/repronim-reprostim/setup_container.sh
+++ b/containers/repronim-reprostim/setup_container.sh
@@ -54,6 +54,9 @@ echo "Install visidata"
 echo "Install py-spy"
 "${PSYCHOPY_VENV_BIN}/pip" install --no-cache-dir py-spy
 
+echo "Install bids-validator-deno"
+"${PSYCHOPY_VENV_BIN}/pip" install --no-cache-dir bids-validator-deno==3.0.1
+
 # Extend PATH to include PsychoPy venv bin so reprostim and other
 # venv tools are accessible system-wide without individual wrappers
 echo "Extending PATH to include PsychoPy venv bin: ${PSYCHOPY_VENV_BIN}"
@@ -72,6 +75,13 @@ echo "Creating wrapper script for reprostim in /usr/local/bin..."
 b="${PSYCHOPY_VENV_BIN}/reprostim"
 echo -e "#!/bin/sh\n$b \"\$@\"" >| /usr/local/bin/reprostim
 chmod a+x /usr/local/bin/reprostim
+
+# Create wrapper for bids-validator-deno in /usr/local/bin so it is usable
+# as a raw (non-python) run mode, same as the reprostim wrapper above
+echo "Creating wrapper script for bids-validator-deno in /usr/local/bin..."
+b="${PSYCHOPY_VENV_BIN}/bids-validator-deno"
+echo -e "#!/bin/sh\n$b \"\$@\"" >| /usr/local/bin/bids-validator-deno
+chmod a+x /usr/local/bin/bids-validator-deno
 
 if [[ "$REPROSTIM_CAPTURE_ENABLED" == "1" ]]; then
   # Build reprostim-capture from source

--- a/tools/ci/test_reprostim_container.sh
+++ b/tools/ci/test_reprostim_container.sh
@@ -52,6 +52,11 @@ export REPROSTIM_CONTAINER_RUN_MODE="rsync"
 ./run_reprostim_container.sh --version
 
 cd "${thisdir}"
+echo Test bids-validator-deno --version
+export REPROSTIM_CONTAINER_RUN_MODE="bids-validator-deno"
+./run_reprostim_container.sh --version
+
+cd "${thisdir}"
 echo Test Python visidata --version
 export REPROSTIM_CONTAINER_RUN_MODE="python"
 ./run_reprostim_container.sh -m visidata --version


### PR DESCRIPTION
- Add `bids-validator` to the `repronim-reprostim` container using the `bids-validator-deno` Python package (`3.0.1`).
- Release `v0.7.35`.